### PR TITLE
Allow user specified temp directory during remap

### DIFF
--- a/pyremap/__init__.py
+++ b/pyremap/__init__.py
@@ -6,5 +6,5 @@ from pyremap.remapper import Remapper
 
 from pyremap.polar import get_polar_descriptor_from_file, get_polar_descriptor
 
-__version_info__ = (0, 0, 4)
+__version_info__ = (0, 0, 5)
 __version__ = '.'.join(str(vi) for vi in __version_info__)


### PR DESCRIPTION
This should solve some problems on compute nodes.

Also, switch to the more up-to-date tempfile approach by making a temp directory.