### PR TITLE
Specify full path to mpi_run in conda envs. 

### DIFF
--- a/pyremap/__init__.py
+++ b/pyremap/__init__.py
@@ -6,5 +6,5 @@ from pyremap.remapper import Remapper
 
 from pyremap.polar import get_polar_descriptor_from_file, get_polar_descriptor
 
-__version_info__ = (0, 0, 5)
+__version_info__ = (0, 0, 6)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/pyremap/remapper.py
+++ b/pyremap/remapper.py
@@ -181,7 +181,12 @@ class Remapper(object):
                 '--no_log']
 
         if mpiTasks > 1:
-            args = ['mpirun', '-np', '{}'.format(mpiTasks)] + args
+            if 'CONDA_PREFIX' in os.environ:
+                mpirun_path = '{}/bin/mpirun'.format(os.environ['CONDA_PREFIX'])
+            else:
+                mpirun_path = 'mpirun'
+
+            args = [mpirun_path, '-np', '{}'.format(mpiTasks)] + args
 
         if self.sourceDescriptor.regional:
             args.append('--src_regional')

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyremap" %}
-{% set version = "0.0.5" %}
+{% set version = "0.0.6" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This allows things to work as expected even when a different (system) verison of `mpirun` has been loaded after the conda env.

Update to v0.0.6 for release