### PR TITLE
Fix error message when nCells don't match

### DIFF
--- a/pyremap/remapper.py
+++ b/pyremap/remapper.py
@@ -455,7 +455,7 @@ class Remapper(object):
                 raise ValueError('data set and remapping source dimension {} '
                                  'don\'t have the same size: {} != {}'.format(
                                      dim, self.src_grid_dims[index],
-                                     len(ds.sizes[dim])))
+                                     ds.sizes[dim]))
 
         if isinstance(ds, xr.DataArray):
             remappedDs = self._remap_data_array(ds, renormalizationThreshold)


### PR DESCRIPTION
If `nCells` from the mapping file and the time series don't match, the error message was getting messed up by an incorrectly formatted argument.