### PR TITLE
Make the `ncremap` `-C` flag optional for MPAS meshes

### DIFF
--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -14,6 +14,7 @@ xarray >=0.10.0
 
 # Development
 pip
+pytest
 
 # Documentation
 mock

--- a/pyremap/remapper.py
+++ b/pyremap/remapper.py
@@ -283,7 +283,8 @@ class Remapper(object):
         # }}}
 
     def remap_file(self, inFileName, outFileName, variableList=None,
-                   overwrite=False, renormalize=None, logger=None):  # {{{
+                   overwrite=False, renormalize=None, logger=None,
+                   replaceMpasFill=False):  # {{{
         """
         Given a source file defining either an MPAS mesh or a lat-lon grid and
         a destination file or set of arrays defining a lat-lon grid, constructs
@@ -312,6 +313,11 @@ class Remapper(object):
 
         logger : ``logging.Logger``, optional
             A logger to which ncclimo output should be redirected
+
+        replaceMpasFill : bool, optional
+            For MPAS meshes, whether add a ``_FillValue`` attribute (missing
+            from MPAS output).  If this has been handled before the call,
+            replacing the fill value again may cause errors.
 
         Raises
         ------
@@ -387,10 +393,12 @@ class Remapper(object):
             args.extend(['-R', ' '.join(regridArgs)])
 
         if isinstance(self.sourceDescriptor, MpasMeshDescriptor):
-            # Note: using the -C (climatology) flag for now because otherwise
-            #       ncremap tries to add a _FillValue attribute that might
-            #       already be present and quits with an error
-            args.extend(['-P', 'mpas', '-C'])
+            args.extend(['-P', 'mpas'])
+            if not replaceMpasFill:
+                # the -C (climatology) flag prevents ncremap from trying to
+                # add a _FillValue attribute that might already be present and
+                # quits with an error
+                args.append('-C')
 
         if variableList is not None:
             args.extend(['-v', ','.join(variableList)])

--- a/pyremap/test/test_interpolate.py
+++ b/pyremap/test/test_interpolate.py
@@ -104,7 +104,8 @@ class TestInterp(TestCase):
         if remap_file:
             # first, test interpolation with ncremap
             remapper.remap_file(inFileName=inFileName,
-                                outFileName=outFileName)
+                                outFileName=outFileName,
+                                replaceMpasFill=True)
 
             assert os.path.exists(outFileName)
             dsRemapped = xarray.open_dataset(outFileName)


### PR DESCRIPTION
This is causing trouble in cases where it's not necessarily needed.

This merge also stops using the `-C flag` in tests.  The test data doesn't have fill values, so it shouldn't be needed. and is causing trouble in OSX.

Finally, this merge adds `pytest` to the development environment (`dev-spec.txt`) for convenience.