### PR TITLE
Add flag to ncremap to always fill values from MPAS meshes

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -13,6 +13,7 @@ Documentation    On GitHub
 `v0.0.11`_        `0.0.11`_
 `v0.0.12`_        `0.0.12`_
 `v0.0.13`_        `0.0.13`_
+`v0.0.14`_        `0.0.14`_
 ================ ===============
 
 .. _`stable`: ../stable/index.html
@@ -24,6 +25,7 @@ Documentation    On GitHub
 .. _`v0.0.11`: ../0.0.11/index.html
 .. _`v0.0.12`: ../0.0.12/index.html
 .. _`v0.0.13`: ../0.0.13/index.html
+.. _`v0.0.14`: ../0.0.14/index.html
 .. _`master`: https://github.com/MPAS-Dev/pyremap/tree/master
 .. _`0.0.6`: https://github.com/MPAS-Dev/pyremap/tree/0.0.6
 .. _`0.0.7`: https://github.com/MPAS-Dev/pyremap/tree/0.0.7
@@ -33,3 +35,4 @@ Documentation    On GitHub
 .. _`0.0.11`: https://github.com/MPAS-Dev/pyremap/tree/0.0.11
 .. _`0.0.12`: https://github.com/MPAS-Dev/pyremap/tree/0.0.12
 .. _`0.0.13`: https://github.com/MPAS-Dev/pyremap/tree/0.0.13
+.. _`0.0.14`: https://github.com/MPAS-Dev/pyremap/tree/0.0.14

--- a/pyremap/__init__.py
+++ b/pyremap/__init__.py
@@ -6,5 +6,5 @@ from pyremap.remapper import Remapper
 
 from pyremap.polar import get_polar_descriptor_from_file, get_polar_descriptor
 
-__version_info__ = (0, 0, 13)
+__version_info__ = (0, 0, 14)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/pyremap/remapper.py
+++ b/pyremap/remapper.py
@@ -425,6 +425,12 @@ class Remapper(object):
                     # and quits with an error
                     args.append('-C')
 
+            if renormalize is not None:
+                # we also want to make sure cells that receive no data are
+                # marked with fill values, even if the source MPAS data
+                # doesn't have a fill value
+                args.append('--add_fill_value')
+
         if variableList is not None:
             args.extend(['-v', ','.join(variableList)])
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyremap" %}
-{% set version = "0.0.13" %}
+{% set version = "0.0.14" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
When we remap MPAS meshes and want to renormalize, we want to make sure the result includes fill values for empty cells even if the source MPAS mesh has no fill values.