### PR TITLE
Fix various problems that led to docs not getting update in v0.0.14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,18 +30,21 @@ jobs:
     displayName: Add conda to PATH
 
   - bash: |
+      set -e
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda create --yes --quiet --name build python=$PYTHON_VERSION conda conda-build
     displayName: Create Anaconda build environment
 
   - bash: |
+      set -e
       eval "$(conda shell.bash hook)"
       conda activate build
       conda build -m "ci/python${PYTHON_VERSION}.yaml" "recipe"
     displayName: Build pyremap
 
   - bash: |
+      set -e
       eval "$(conda shell.bash hook)"
       conda activate build
       conda create --yes --quiet --name test -c ${CONDA_PREFIX}/conda-bld/ \
@@ -49,12 +52,14 @@ jobs:
     displayName: Create Anaconda test environment
 
   - bash: |
+      set -e
       eval "$(conda shell.bash hook)"
       conda activate test
       pytest --pyargs pyremap
     displayName: pytest
 
   - bash: |
+      set -e
       eval "$(conda shell.bash hook)"
       conda activate build
       conda create --yes --quiet --name docs -c ${CONDA_PREFIX}/conda-bld/ \
@@ -63,6 +68,7 @@ jobs:
     displayName: Create Anaconda docs environment
 
   - bash: |
+      set -e
       eval "$(conda shell.bash hook)"
       conda activate docs
 
@@ -146,18 +152,21 @@ jobs:
     displayName: Fix permissions
 
   - bash: |
+      set -e
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda create --yes --quiet --name build python=$PYTHON_VERSION conda conda-build
     displayName: Create Anaconda build environment
 
   - bash: |
+      set -e
       eval "$(conda shell.bash hook)"
       conda activate build
       conda build -m "ci/python${PYTHON_VERSION}.yaml" "recipe"
     displayName: Build pyremap
 
   - bash: |
+      set -e
       eval "$(conda shell.bash hook)"
       conda activate build
       conda create --yes --quiet --name test -c ${CONDA_PREFIX}/conda-bld/ \
@@ -165,6 +174,7 @@ jobs:
     displayName: Create Anaconda test environment
 
   - bash: |
+      set -e
       eval "$(conda shell.bash hook)"
       conda activate test
       pytest --pyargs pyremap

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ jobs:
       eval "$(conda shell.bash hook)"
       conda activate build
       conda create --yes --quiet --name docs -c ${CONDA_PREFIX}/conda-bld/ \
-          python=$PYTHON_VERSION pyremap sphinx mock sphinx_rtd_theme m2r
+          python=$PYTHON_VERSION pyremap sphinx mock sphinx_rtd_theme m2r2
     condition: eq(variables['python.version'], '3.8')
     displayName: Create Anaconda docs environment
 
@@ -161,7 +161,7 @@ jobs:
       eval "$(conda shell.bash hook)"
       conda activate build
       conda create --yes --quiet --name test -c ${CONDA_PREFIX}/conda-bld/ \
-          python=$PYTHON_VERSION pyremap pytest sphinx mock sphinx_rtd_theme m2r
+          python=$PYTHON_VERSION pyremap pytest sphinx mock sphinx_rtd_theme m2r2
     displayName: Create Anaconda test environment
 
   - bash: |

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -21,4 +21,4 @@ mock
 pillow
 sphinx
 sphinx_rtd_theme
-m2r
+m2r2

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -14,6 +14,7 @@ Documentation    On GitHub
 `v0.0.12`_        `0.0.12`_
 `v0.0.13`_        `0.0.13`_
 `v0.0.14`_        `0.0.14`_
+`v0.0.15`_        `0.0.15`_
 ================ ===============
 
 .. _`stable`: ../stable/index.html
@@ -26,6 +27,7 @@ Documentation    On GitHub
 .. _`v0.0.12`: ../0.0.12/index.html
 .. _`v0.0.13`: ../0.0.13/index.html
 .. _`v0.0.14`: ../0.0.14/index.html
+.. _`v0.0.15`: ../0.0.15/index.html
 .. _`master`: https://github.com/MPAS-Dev/pyremap/tree/master
 .. _`0.0.6`: https://github.com/MPAS-Dev/pyremap/tree/0.0.6
 .. _`0.0.7`: https://github.com/MPAS-Dev/pyremap/tree/0.0.7
@@ -36,3 +38,4 @@ Documentation    On GitHub
 .. _`0.0.12`: https://github.com/MPAS-Dev/pyremap/tree/0.0.12
 .. _`0.0.13`: https://github.com/MPAS-Dev/pyremap/tree/0.0.13
 .. _`0.0.14`: https://github.com/MPAS-Dev/pyremap/tree/0.0.14
+.. _`0.0.15`: https://github.com/MPAS-Dev/pyremap/tree/0.0.15

--- a/pyremap/__init__.py
+++ b/pyremap/__init__.py
@@ -6,5 +6,5 @@ from pyremap.remapper import Remapper
 
 from pyremap.polar import get_polar_descriptor_from_file, get_polar_descriptor
 
-__version_info__ = (0, 0, 14)
+__version_info__ = (0, 0, 15)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/pyremap/docs/parse_quick_start.py
+++ b/pyremap/docs/parse_quick_start.py
@@ -1,4 +1,4 @@
-from m2r import convert
+from m2r2 import convert
 
 
 def build_quick_start():

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyremap" %}
-{% set version = "0.0.14" %}
+{% set version = "0.0.15" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
1. Switch from unmaintained m2r to the better maintained m2r2
2. Make sure errors in bash sections cause failures in Azure
3. Update to v0.0.15 for a release

I will copy the (identical) 0.0.15 documentation back to 0.0.14 once this is successfully update.