### PR TITLE
Rename lon/lat dimension when mapping to lon/lat grid

### DIFF
--- a/pyremap/remapper.py
+++ b/pyremap/remapper.py
@@ -449,10 +449,11 @@ class Remapper(object):
                 self.sourceDescriptor.xVarName)])
 
         if isinstance(self.destinationDescriptor, LatLonGridDescriptor):
-            regridArgs.extend(['--rgr lat_nm_out={}'.format(
-                self.destinationDescriptor.latVarName),
-                '--rgr lon_nm_out={}'.format(
-                self.destinationDescriptor.lonVarName)])
+            regridArgs.extend([
+                f'--rgr lat_nm_out={self.destinationDescriptor.latVarName}',
+                f'--rgr lon_nm_out={self.destinationDescriptor.lonVarName}',
+                f'--rgr lat_dmn_nm={self.destinationDescriptor.latVarName}',
+                f'--rgr lon_dmn_nm={self.destinationDescriptor.lonVarName}'])
         elif isinstance(self.destinationDescriptor, ProjectionGridDescriptor):
             regridArgs.extend(['--rgr lat_dmn_nm={}'.format(
                 self.destinationDescriptor.yVarName),


### PR DESCRIPTION
Before this change, remapping from a stereographic to a lon/lat grid leaves dimensions x and y (but coordinates lon and lat), whereas this merge makes sure the dimensions and coordinates have the same name as expected by the CF convensions.