### PR TITLE
Add format and engine attributes to MeshDescriptor 

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyremap" %}
-{% set version = "0.0.16" %}
+{% set version = "1.0.0" %}
 
 package:
   name: {{ name|lower }}

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -16,6 +16,7 @@ Documentation    On GitHub
 `v0.0.14`_        `0.0.14`_
 `v0.0.15`_        `0.0.15`_
 `v0.0.16`_        `0.0.16`_
+`v1.0.0`_         `1.0.0`_
 ================ ===============
 
 .. _`stable`: ../stable/index.html
@@ -30,6 +31,7 @@ Documentation    On GitHub
 .. _`v0.0.14`: ../0.0.14/index.html
 .. _`v0.0.15`: ../0.0.15/index.html
 .. _`v0.0.16`: ../0.0.16/index.html
+.. _`v1.0.0`: ../1.0.0/index.html
 .. _`main`: https://github.com/MPAS-Dev/pyremap/tree/main
 .. _`0.0.6`: https://github.com/MPAS-Dev/pyremap/tree/0.0.6
 .. _`0.0.7`: https://github.com/MPAS-Dev/pyremap/tree/0.0.7
@@ -42,3 +44,4 @@ Documentation    On GitHub
 .. _`0.0.14`: https://github.com/MPAS-Dev/pyremap/tree/0.0.14
 .. _`0.0.15`: https://github.com/MPAS-Dev/pyremap/tree/0.0.15
 .. _`0.0.16`: https://github.com/MPAS-Dev/pyremap/tree/0.0.16
+.. _`1.0.0`: https://github.com/MPAS-Dev/pyremap/tree/1.0.0

--- a/pyremap/__init__.py
+++ b/pyremap/__init__.py
@@ -10,5 +10,5 @@ from pyremap.descriptor import (
 from pyremap.polar import get_polar_descriptor, get_polar_descriptor_from_file
 from pyremap.remapper import Remapper
 
-__version_info__ = (0, 0, 16)
+__version_info__ = (1, 0, 0)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/pyremap/descriptor/lat_lon_2d_grid_descriptor.py
+++ b/pyremap/descriptor/lat_lon_2d_grid_descriptor.py
@@ -136,7 +136,7 @@ class LatLon2DGridDescriptor(MeshDescriptor):
         scripFileName : str
             The path to which the SCRIP file should be written
         """
-        outFile = netCDF4.Dataset(scripFileName, 'w')
+        outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
 
         nLat, nLon = self.lat.shape
 

--- a/pyremap/descriptor/lat_lon_grid_descriptor.py
+++ b/pyremap/descriptor/lat_lon_grid_descriptor.py
@@ -212,7 +212,7 @@ class LatLonGridDescriptor(MeshDescriptor):
         scripFileName : str
             The path to which the SCRIP file should be written
         """
-        outFile = netCDF4.Dataset(scripFileName, 'w')
+        outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
 
         nLat = len(self.lat)
         nLon = len(self.lon)
@@ -296,7 +296,8 @@ class LatLonGridDescriptor(MeshDescriptor):
         ds_out.attrs['gridType'] = 'unstructured mesh'
         ds_out.attrs['version'] = '0.9'
 
-        ds_out.to_netcdf(esmfFileName)
+        ds_out.to_netcdf(esmfFileName, format=self.format,
+                         engine=self.engine)
 
     def _set_coords(self, latVarName, lonVarName, latDimName,
                     lonDimName):

--- a/pyremap/descriptor/mesh_descriptor.py
+++ b/pyremap/descriptor/mesh_descriptor.py
@@ -31,6 +31,14 @@ class MeshDescriptor:
     coords : dict
         A dictionary that can be used to construct an xarray.DataArray for each
         coordinate in the mesh or grid
+
+    format : {'NETCDF4', 'NETCDF4_CLASSIC', 'NETCDF3_64BIT',
+              'NETCDF3_CLASSIC'}
+        The NetCDF file format to use.  Default is ``'NETCDF4'``
+
+    engine : {'netcdf4', 'scipy', 'h5netcdf'}
+        The library to use for xarray NetCDF output.  The default is
+        ``'netcdf4'``
     """
     def __init__(self, meshName=None, regional=None):
         """
@@ -50,6 +58,8 @@ class MeshDescriptor:
         self.dims = None
         self.dimSizes = None
         self.coords = None
+        self.format = 'NETCDF4'
+        self.engine = None
 
     def to_scrip(self, scripFileName):
         """

--- a/pyremap/descriptor/mpas_edge_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_edge_mesh_descriptor.py
@@ -78,7 +78,7 @@ class MpasEdgeMeshDescriptor(MeshDescriptor):
         """
 
         inFile = netCDF4.Dataset(self.fileName, 'r')
-        outFile = netCDF4.Dataset(scripFileName, 'w')
+        outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
 
         # Get info from input file
         latCell = inFile.variables['latCell'][:]
@@ -214,4 +214,5 @@ class MpasEdgeMeshDescriptor(MeshDescriptor):
         ds_out.attrs['gridType'] = 'unstructured mesh'
         ds_out.attrs['version'] = '0.9'
 
-        ds_out.to_netcdf(esmfFileName)
+        ds_out.to_netcdf(esmfFileName, format=self.format,
+                         engine=self.engine)

--- a/pyremap/descriptor/mpas_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_mesh_descriptor.py
@@ -101,7 +101,7 @@ class MpasMeshDescriptor(MeshDescriptor):
             raise ValueError('A SCRIP file won\'t work for remapping vertices')
 
         inFile = netCDF4.Dataset(self.fileName, 'r')
-        outFile = netCDF4.Dataset(scripFileName, 'w')
+        outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
 
         # Get info from input file
         latCell = inFile.variables['latCell'][:]
@@ -193,4 +193,5 @@ class MpasMeshDescriptor(MeshDescriptor):
             ds_out.attrs['gridType'] = 'unstructured mesh'
             ds_out.attrs['version'] = '0.9'
 
-            ds_out.to_netcdf(esmfFileName)
+            ds_out.to_netcdf(esmfFileName, format=self.format,
+                             engine=self.engine)

--- a/pyremap/descriptor/point_collection_descriptor.py
+++ b/pyremap/descriptor/point_collection_descriptor.py
@@ -85,7 +85,7 @@ class PointCollectionDescriptor(MeshDescriptor):
             The path to which the SCRIP file should be written
         """
 
-        outFile = netCDF4.Dataset(scripFileName, 'w')
+        outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
 
         nPoints = len(self.lat)
 
@@ -166,4 +166,5 @@ class PointCollectionDescriptor(MeshDescriptor):
         ds_out.attrs['gridType'] = 'unstructured mesh'
         ds_out.attrs['version'] = '0.9'
 
-        ds_out.to_netcdf(esmfFileName)
+        ds_out.to_netcdf(esmfFileName, format=self.format,
+                         engine=self.engine)

--- a/pyremap/descriptor/projection_grid_descriptor.py
+++ b/pyremap/descriptor/projection_grid_descriptor.py
@@ -184,7 +184,7 @@ class ProjectionGridDescriptor(MeshDescriptor):
         scripFileName : str
             The path to which the SCRIP file should be written
         """
-        outFile = netCDF4.Dataset(scripFileName, 'w')
+        outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
 
         nx = len(self.x)
         ny = len(self.y)
@@ -274,7 +274,8 @@ class ProjectionGridDescriptor(MeshDescriptor):
         ds_out.attrs['gridType'] = 'unstructured mesh'
         ds_out.attrs['version'] = '0.9'
 
-        ds_out.to_netcdf(esmfFileName)
+        ds_out.to_netcdf(esmfFileName, format=self.format,
+                         engine=self.engine)
 
     def project_to_lat_lon(self, X, Y):
         """


### PR DESCRIPTION
These are used to set the NetCDF format and (where applicable)
the xarray output engine.

This merge also updates to v1.0.0