### PR TITLE
Add `MpasCellMeshDescriptor` and `MpasVertexMeshDescriptor`

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyremap" %}
-{% set version = "1.0.1" %}
+{% set version = "1.1.0" %}
 
 package:
   name: {{ name|lower }}

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -18,6 +18,7 @@ Documentation    On GitHub
 `v0.0.16`_        `0.0.16`_
 `v1.0.0`_         `1.0.0`_
 `v1.0.1`_         `1.0.1`_
+`v1.1.0`_         `1.1.0`_
 ================ ===============
 
 .. _`stable`: ../stable/index.html
@@ -34,6 +35,7 @@ Documentation    On GitHub
 .. _`v0.0.16`: ../0.0.16/index.html
 .. _`v1.0.0`: ../1.0.0/index.html
 .. _`v1.0.1`: ../1.0.1/index.html
+.. _`v1.1.0`: ../1.1.0/index.html
 .. _`main`: https://github.com/MPAS-Dev/pyremap/tree/main
 .. _`0.0.6`: https://github.com/MPAS-Dev/pyremap/tree/0.0.6
 .. _`0.0.7`: https://github.com/MPAS-Dev/pyremap/tree/0.0.7
@@ -48,3 +50,4 @@ Documentation    On GitHub
 .. _`0.0.16`: https://github.com/MPAS-Dev/pyremap/tree/0.0.16
 .. _`1.0.0`: https://github.com/MPAS-Dev/pyremap/tree/1.0.0
 .. _`1.0.1`: https://github.com/MPAS-Dev/pyremap/tree/1.0.1
+.. _`1.1.0`: https://github.com/MPAS-Dev/pyremap/tree/1.1.0

--- a/examples/make_mpas_to_lat_lon_mapping.py
+++ b/examples/make_mpas_to_lat_lon_mapping.py
@@ -10,18 +10,18 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/pyremap/main/LICENSE
 
-'''
+"""
 Creates a mapping file that can be used with ncremap (NCO) to remap MPAS files
 to a latitude/longitude grid.
 
 Usage: Copy this script into the main MPAS-Analysis directory (up one level).
 Modify the grid name, the path to the MPAS grid file and the output grid
 resolution.
-'''
+"""
 
 import xarray
 
-from pyremap import MpasMeshDescriptor, Remapper, get_lat_lon_descriptor
+from pyremap import MpasCellMeshDescriptor, Remapper, get_lat_lon_descriptor
 
 # replace with the MPAS mesh name
 inGridName = 'oQU240'
@@ -31,20 +31,20 @@ inGridName = 'oQU240'
 # https://web.lcrc.anl.gov/public/e3sm/inputdata/ocn/mpas-o/oQU240/ocean.QU.240km.151209.nc
 inGridFileName = 'ocean.QU.240km.151209.nc'
 
-inDescriptor = MpasMeshDescriptor(inGridFileName, inGridName)
+inDescriptor = MpasCellMeshDescriptor(inGridFileName, inGridName)
 
 # modify the resolution of the global lat-lon grid as desired
 outDescriptor = get_lat_lon_descriptor(dLon=0.5, dLat=0.5)
 outGridName = outDescriptor.meshName
 
-mappingFileName = 'map_{}_to_{}_bilinear.nc'.format(inGridName, outGridName)
+mappingFileName = f'map_{inGridName}_to_{outGridName}_bilinear.nc'
 
 
 remapper = Remapper(inDescriptor, outDescriptor, mappingFileName)
 
 remapper.build_mapping_file(method='bilinear', mpiTasks=1)
 
-outFileName = 'temp_{}.nc'.format(outGridName)
+outFileName = f'temp_{outGridName}.nc'
 ds = xarray.open_dataset(inGridFileName)
 dsOut = xarray.Dataset()
 dsOut['temperature'] = ds['temperature']

--- a/examples/remap_stereographic.py
+++ b/examples/remap_stereographic.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
-'''
+"""
 Creates a mapping file and remaps the variables from an input file on an
 Antarctic grid to another grid with the same extent but a different resolution.
 The mapping file can be used with ncremap (NCO) to remap MPAS files between
 these same gridss.
 
 Usage: Copy this script into the main MPAS-Analysis directory (up one level).
-'''
+"""
 
 import numpy
 import xarray
@@ -33,7 +33,7 @@ args = parser.parse_args()
 
 
 if args.method not in ['bilinear', 'neareststod', 'conserve']:
-    raise ValueError('Unexpected method {}'.format(args.method))
+    raise ValueError(f'Unexpected method {args.method}')
 
 dsIn = xarray.open_dataset(args.inFileName)
 
@@ -43,7 +43,7 @@ dx = int((x[1]-x[0])/1000.)
 Lx = int((x[-1] - x[0])/1000.)
 Ly = int((y[-1] - y[0])/1000.)
 
-inMeshName = '{}x{}km_{}km_Antarctic_stereo'.format(Lx, Ly, dx)
+inMeshName = f'{Lx}x{Ly}km_{dx}km_Antarctic_stereo'
 
 projection = get_antarctic_stereographic_projection()
 
@@ -58,13 +58,12 @@ xOut = x[0] + outRes*numpy.arange(nxOut)
 yOut = y[0] + outRes*numpy.arange(nyOut)
 
 
-outMeshName = '{}x{}km_{}km_Antarctic_stereo'.format(Lx, Ly, args.resolution)
+outMeshName = f'{Lx}x{Ly}km_{args.resolution}km_Antarctic_stereo'
 
 outDescriptor = ProjectionGridDescriptor.create(projection, xOut, yOut,
                                                 outMeshName)
 
-mappingFileName = 'map_{}_to_{}_{}.nc'.format(inMeshName, outMeshName,
-                                              args.method)
+mappingFileName = f'map_{inMeshName}_to_{outMeshName}_{args.method}.nc'
 
 remapper = Remapper(inDescriptor, outDescriptor, mappingFileName)
 

--- a/pyremap/__init__.py
+++ b/pyremap/__init__.py
@@ -1,8 +1,10 @@
 from pyremap.descriptor import (
     LatLon2DGridDescriptor,
     LatLonGridDescriptor,
+    MpasCellMeshDescriptor,
     MpasEdgeMeshDescriptor,
     MpasMeshDescriptor,
+    MpasVertexMeshDescriptor,
     PointCollectionDescriptor,
     ProjectionGridDescriptor,
     get_lat_lon_descriptor,

--- a/pyremap/__init__.py
+++ b/pyremap/__init__.py
@@ -12,5 +12,5 @@ from pyremap.descriptor import (
 from pyremap.polar import get_polar_descriptor, get_polar_descriptor_from_file
 from pyremap.remapper import Remapper
 
-__version_info__ = (1, 0, 1)
+__version_info__ = (1, 1, 0)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/pyremap/descriptor/__init__.py
+++ b/pyremap/descriptor/__init__.py
@@ -17,6 +17,7 @@ from pyremap.descriptor.lat_lon_grid_descriptor import (
     get_lat_lon_descriptor,
 )
 from pyremap.descriptor.mesh_descriptor import MeshDescriptor
+from pyremap.descriptor.mpas_cell_mesh_descriptor import MpasCellMeshDescriptor
 from pyremap.descriptor.mpas_edge_mesh_descriptor import MpasEdgeMeshDescriptor
 from pyremap.descriptor.mpas_mesh_descriptor import MpasMeshDescriptor
 from pyremap.descriptor.point_collection_descriptor import (

--- a/pyremap/descriptor/__init__.py
+++ b/pyremap/descriptor/__init__.py
@@ -20,6 +20,9 @@ from pyremap.descriptor.mesh_descriptor import MeshDescriptor
 from pyremap.descriptor.mpas_cell_mesh_descriptor import MpasCellMeshDescriptor
 from pyremap.descriptor.mpas_edge_mesh_descriptor import MpasEdgeMeshDescriptor
 from pyremap.descriptor.mpas_mesh_descriptor import MpasMeshDescriptor
+from pyremap.descriptor.mpas_vertex_mesh_descriptor import (
+    MpasVertexMeshDescriptor,
+)
 from pyremap.descriptor.point_collection_descriptor import (
     PointCollectionDescriptor,
 )

--- a/pyremap/descriptor/lat_lon_2d_grid_descriptor.py
+++ b/pyremap/descriptor/lat_lon_2d_grid_descriptor.py
@@ -9,14 +9,13 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/pyremap/main/LICENSE
 
-import sys
-
 import netCDF4
 import numpy
 import xarray
 
 from pyremap.descriptor.mesh_descriptor import MeshDescriptor
 from pyremap.descriptor.utility import (
+    add_history,
     create_scrip,
     interp_extrap_corners_2d,
     round_res,
@@ -120,11 +119,7 @@ class LatLon2DGridDescriptor(MeshDescriptor):
         descriptor._set_coords(latVarName, lonVarName, ds[latVarName].dims[0],
                                ds[latVarName].dims[1])
 
-        if 'history' in ds.attrs:
-            descriptor.history = '\n'.join([ds.attrs['history'],
-                                            ' '.join(sys.argv[:])])
-        else:
-            descriptor.history = sys.argv[:]
+        descriptor.history = add_history(ds=ds)
         return descriptor
 
     def to_scrip(self, scripFileName):

--- a/pyremap/descriptor/lat_lon_grid_descriptor.py
+++ b/pyremap/descriptor/lat_lon_grid_descriptor.py
@@ -9,14 +9,13 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/pyremap/main/LICENSE
 
-import sys
-
 import netCDF4
 import numpy
 import xarray
 
 from pyremap.descriptor.mesh_descriptor import MeshDescriptor
 from pyremap.descriptor.utility import (
+    add_history,
     create_scrip,
     interp_extrap_corner,
     round_res,
@@ -157,11 +156,7 @@ class LatLonGridDescriptor(MeshDescriptor):
         descriptor._set_coords(latVarName, lonVarName, ds[latVarName].dims[0],
                                ds[lonVarName].dims[0])
 
-        if 'history' in ds.attrs:
-            descriptor.history = '\n'.join([ds.attrs['history'],
-                                            ' '.join(sys.argv[:])])
-        else:
-            descriptor.history = sys.argv[:]
+        descriptor.history = add_history(ds=ds)
         return descriptor
 
     @classmethod
@@ -199,7 +194,7 @@ class LatLonGridDescriptor(MeshDescriptor):
         descriptor.lon = 0.5 * (lonCorner[0:-1] + lonCorner[1:])
         descriptor.lat = 0.5 * (latCorner[0:-1] + latCorner[1:])
         descriptor.units = units
-        descriptor.history = sys.argv[:]
+        descriptor.history = add_history()
         descriptor._set_coords('lat', 'lon', 'lat', 'lon')
         return descriptor
 

--- a/pyremap/descriptor/mpas_cell_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_cell_mesh_descriptor.py
@@ -9,7 +9,6 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/pyremap/main/LICENSE
 
-import sys
 import warnings
 
 import netCDF4
@@ -17,7 +16,7 @@ import numpy
 import xarray
 
 from pyremap.descriptor.mesh_descriptor import MeshDescriptor
-from pyremap.descriptor.utility import create_scrip
+from pyremap.descriptor.utility import add_history, create_scrip
 
 
 class MpasCellMeshDescriptor(MeshDescriptor):
@@ -32,6 +31,9 @@ class MpasCellMeshDescriptor(MeshDescriptor):
 
     fileName : str
         The path of the file containing the MPAS mesh
+
+    history : str
+        The history attribute written to SCRIP files
     """
     def __init__(self, fileName, meshName=None, vertices=False):
         """
@@ -94,6 +96,8 @@ class MpasCellMeshDescriptor(MeshDescriptor):
                 self.dims = ['nCells']
             self.dimSize = [ds.dims[dim] for dim in self.dims]
 
+            self.history = add_history(ds=ds)
+
     def to_scrip(self, scripFileName):
         """
         Given an MPAS mesh file, create a SCRIP file based on the mesh.
@@ -148,13 +152,7 @@ class MpasCellMeshDescriptor(MeshDescriptor):
         outFile.variables['grid_corner_lat'][:] = grid_corner_lat[:]
         outFile.variables['grid_corner_lon'][:] = grid_corner_lon[:]
 
-        # Update history attribute of netCDF file
-        if hasattr(inFile, 'history'):
-            newhist = '\n'.join([getattr(inFile, 'history'),
-                                 ' '.join(sys.argv[:])])
-        else:
-            newhist = sys.argv[:]
-        setattr(outFile, 'history', newhist)
+        setattr(outFile, 'history', self.history)
 
         inFile.close()
         outFile.close()

--- a/pyremap/descriptor/mpas_cell_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_cell_mesh_descriptor.py
@@ -1,0 +1,203 @@
+# This software is open source software available under the BSD-3 license.
+#
+# Copyright (c) 2022 Triad National Security, LLC. All rights reserved.
+# Copyright (c) 2022 Lawrence Livermore National Security, LLC. All rights
+# reserved.
+# Copyright (c) 2022 UT-Battelle, LLC. All rights reserved.
+#
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at
+# https://raw.githubusercontent.com/MPAS-Dev/pyremap/main/LICENSE
+
+import sys
+import warnings
+
+import netCDF4
+import numpy
+import xarray
+
+from pyremap.descriptor.mesh_descriptor import MeshDescriptor
+from pyremap.descriptor.utility import create_scrip
+
+
+class MpasCellMeshDescriptor(MeshDescriptor):
+    """
+    A class for describing an MPAS cell mesh
+
+    Attributes
+    ----------
+    vertices : bool
+        Whether the mapping is to or from vertices instead of corners
+        (for non-conservative remapping)
+
+    fileName : str
+        The path of the file containing the MPAS mesh
+    """
+    def __init__(self, fileName, meshName=None, vertices=False):
+        """
+        Constructor stores the file name
+
+        Parameters
+        ----------
+        fileName : str
+            The path of the file containing the MPAS mesh
+
+        meshName : str, optional
+            The name of the MPAS mesh (e.g. ``'oEC60to30'`` or
+            ``'oRRS18to6'``).  If not provided, the data set in ``fileName``
+            must have a global attribute ``meshName`` that will be used
+            instead.
+
+        vertices : bool, optional
+            Whether the mapping is to or from vertices instead of corners
+            (for non-conservative remapping)
+        """
+        super().__init__()
+
+        if vertices:
+            warnings.warn('Creating a MpasCellMeshDescriptor with '
+                          'vertices=True is deprecated and will be removed in '
+                          'the next release. Use MpasVertexMeshDescriptor '
+                          'instead.', DeprecationWarning)
+
+        self.vertices = vertices
+
+        with xarray.open_dataset(fileName) as ds:
+
+            if meshName is None:
+                if 'meshName' not in ds.attrs:
+                    raise ValueError('No meshName provided or found in file.')
+                self.meshName = ds.attrs['meshName']
+            else:
+                self.meshName = meshName
+
+            self.fileName = fileName
+            self.regional = True
+
+            if vertices:
+                # build coords
+                self.coords = {'latVertex': {'dims': 'nVertices',
+                                             'data': ds.latVertex.values,
+                                             'attrs': {'units': 'radians'}},
+                               'lonVertex': {'dims': 'nVertices',
+                                             'data': ds.lonVertex.values,
+                                             'attrs': {'units': 'radians'}}}
+                self.dims = ['nVertices']
+            else:
+                # build coords
+                self.coords = {'latCell': {'dims': 'nCells',
+                                           'data': ds.latCell.values,
+                                           'attrs': {'units': 'radians'}},
+                               'lonCell': {'dims': 'nCells',
+                                           'data': ds.lonCell.values,
+                                           'attrs': {'units': 'radians'}}}
+                self.dims = ['nCells']
+            self.dimSize = [ds.dims[dim] for dim in self.dims]
+
+    def to_scrip(self, scripFileName):
+        """
+        Given an MPAS mesh file, create a SCRIP file based on the mesh.
+
+        Parameters
+        ----------
+        scripFileName : str
+            The path to which the SCRIP file should be written
+        """
+        if self.vertices:
+            raise ValueError('A SCRIP file won\'t work for remapping vertices')
+
+        inFile = netCDF4.Dataset(self.fileName, 'r')
+        outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
+
+        # Get info from input file
+        latCell = inFile.variables['latCell'][:]
+        lonCell = inFile.variables['lonCell'][:]
+        latVertex = inFile.variables['latVertex'][:]
+        lonVertex = inFile.variables['lonVertex'][:]
+        verticesOnCell = inFile.variables['verticesOnCell'][:]
+        nEdgesOnCell = inFile.variables['nEdgesOnCell'][:]
+        nCells = len(inFile.dimensions['nCells'])
+        maxVertices = len(inFile.dimensions['maxEdges'])
+        areaCell = inFile.variables['areaCell'][:]
+        sphereRadius = float(inFile.sphere_radius)
+
+        create_scrip(outFile, grid_size=nCells, grid_corners=maxVertices,
+                     grid_rank=1, units='radians', meshName=self.meshName)
+
+        grid_area = outFile.createVariable('grid_area', 'f8', ('grid_size',))
+        grid_area.units = 'radian^2'
+        # SCRIP uses square radians
+        grid_area[:] = areaCell[:] / (sphereRadius**2)
+
+        outFile.variables['grid_center_lat'][:] = latCell[:]
+        outFile.variables['grid_center_lon'][:] = lonCell[:]
+        outFile.variables['grid_dims'][:] = nCells
+        outFile.variables['grid_imask'][:] = 1
+
+        # grid corners:
+        grid_corner_lon = numpy.zeros((nCells, maxVertices))
+        grid_corner_lat = numpy.zeros((nCells, maxVertices))
+        for iVertex in range(maxVertices):
+            cellIndices = numpy.arange(nCells)
+            # repeat the last vertex wherever iVertex > nEdgesOnCell
+            localVertexIndices = numpy.minimum(nEdgesOnCell - 1, iVertex)
+            vertexIndices = verticesOnCell[cellIndices, localVertexIndices] - 1
+            grid_corner_lat[cellIndices, iVertex] = latVertex[vertexIndices]
+            grid_corner_lon[cellIndices, iVertex] = lonVertex[vertexIndices]
+
+        outFile.variables['grid_corner_lat'][:] = grid_corner_lat[:]
+        outFile.variables['grid_corner_lon'][:] = grid_corner_lon[:]
+
+        # Update history attribute of netCDF file
+        if hasattr(inFile, 'history'):
+            newhist = '\n'.join([getattr(inFile, 'history'),
+                                 ' '.join(sys.argv[:])])
+        else:
+            newhist = sys.argv[:]
+        setattr(outFile, 'history', newhist)
+
+        inFile.close()
+        outFile.close()
+
+    def to_esmf(self, esmfFileName):
+        """
+        Create an ESMF mesh file for the mesh
+
+        Parameters
+        ----------
+        esmfFileName : str
+            The path to which the ESMF mesh file should be written
+        """
+        with xarray.open_dataset(self.fileName) as ds:
+
+            nodeCount = ds.sizes['nVertices']
+            elementCount = ds.sizes['nCells']
+            coordDim = 2
+
+            nodeCoords = numpy.zeros((nodeCount, coordDim))
+            nodeCoords[:, 0] = ds.lonVertex.values
+            nodeCoords[:, 1] = ds.latVertex.values
+            centerCoords = numpy.zeros((elementCount, coordDim))
+            centerCoords[:, 0] = ds.lonCell.values
+            centerCoords[:, 1] = ds.latCell.values
+
+            elementConn = ds.verticesOnCell.values
+            elementConn[elementConn == nodeCount + 1] = -1
+
+            ds_out = xarray.Dataset()
+            ds_out['nodeCoords'] = (('nodeCount', 'coordDim'), nodeCoords)
+            ds_out.nodeCoords.attrs['units'] = 'radians'
+            ds_out['centerCoords'] = \
+                (('elementCount', 'coordDim'), centerCoords)
+            ds_out.centerCoords.attrs['units'] = 'radians'
+            ds_out['elementConn'] = \
+                (('elementCount', 'maxNodePElement'), elementConn)
+            ds_out.elementConn.attrs['start_index'] = 1
+            ds_out.elementConn.attrs['_FillValue'] = -1
+            ds_out['numElementConn'] = \
+                (('elementCount',), ds.nEdgesOnCell.values)
+            ds_out.attrs['gridType'] = 'unstructured mesh'
+            ds_out.attrs['version'] = '0.9'
+
+            ds_out.to_netcdf(esmfFileName, format=self.format,
+                             engine=self.engine)

--- a/pyremap/descriptor/mpas_edge_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_edge_mesh_descriptor.py
@@ -9,14 +9,12 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/pyremap/main/LICENSE
 
-import sys
-
 import netCDF4
 import numpy as np
 import xarray as xr
 
 from pyremap.descriptor.mesh_descriptor import MeshDescriptor
-from pyremap.descriptor.utility import create_scrip
+from pyremap.descriptor.utility import add_history, create_scrip
 
 
 class MpasEdgeMeshDescriptor(MeshDescriptor):
@@ -27,6 +25,9 @@ class MpasEdgeMeshDescriptor(MeshDescriptor):
     ----------
     fileName : str
         The path of the file containing the MPAS mesh
+
+    history : str
+        The history attribute written to SCRIP files
     """
     def __init__(self, fileName, meshName=None):
         """
@@ -66,6 +67,8 @@ class MpasEdgeMeshDescriptor(MeshDescriptor):
                                        'attrs': {'units': 'radians'}}}
             self.dims = ['nEdges']
             self.dimSize = [ds.dims[dim] for dim in self.dims]
+
+            self.history = add_history(ds=ds)
 
     def to_scrip(self, scripFileName):
         """
@@ -143,13 +146,7 @@ class MpasEdgeMeshDescriptor(MeshDescriptor):
         outFile.variables['grid_corner_lat'][:] = grid_corner_lat[:]
         outFile.variables['grid_corner_lon'][:] = grid_corner_lon[:]
 
-        # Update history attribute of netCDF file
-        if hasattr(inFile, 'history'):
-            newhist = '\n'.join([getattr(inFile, 'history'),
-                                 ' '.join(sys.argv[:])])
-        else:
-            newhist = sys.argv[:]
-        setattr(outFile, 'history', newhist)
+        setattr(outFile, 'history', self.history)
 
         inFile.close()
         outFile.close()

--- a/pyremap/descriptor/mpas_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_mesh_descriptor.py
@@ -9,29 +9,15 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/pyremap/main/LICENSE
 
-import sys
+import warnings
 
-import netCDF4
-import numpy
-import xarray
-
-from pyremap.descriptor.mesh_descriptor import MeshDescriptor
-from pyremap.descriptor.utility import create_scrip
+from pyremap.descriptor.mpas_cell_mesh_descriptor import MpasCellMeshDescriptor
 
 
-class MpasMeshDescriptor(MeshDescriptor):
+class MpasMeshDescriptor(MpasCellMeshDescriptor):
     """
     A class for describing an MPAS cell mesh (which also supports
     non-conservative remapping from vertices)
-
-    Attributes
-    ----------
-    vertices : bool
-        Whether the mapping is to or from vertices instead of corners
-        (for non-conservative remapping)
-
-    fileName : str
-        The path of the file containing the MPAS mesh
     """
     def __init__(self, fileName, meshName=None, vertices=False):
         """
@@ -52,146 +38,8 @@ class MpasMeshDescriptor(MeshDescriptor):
             Whether the mapping is to or from vertices instead of corners
             (for non-conservative remapping)
         """
-        super().__init__()
+        warnings.warn('MpasMeshDescriptor is deprecated and will be removed '
+                      'in the next release. Use MpasCellMeshDescriptor '
+                      'instead.', DeprecationWarning)
 
-        self.vertices = vertices
-
-        with xarray.open_dataset(fileName) as ds:
-
-            if meshName is None:
-                if 'meshName' not in ds.attrs:
-                    raise ValueError('No meshName provided or found in file.')
-                self.meshName = ds.attrs['meshName']
-            else:
-                self.meshName = meshName
-
-            self.fileName = fileName
-            self.regional = True
-
-            if vertices:
-                # build coords
-                self.coords = {'latVertex': {'dims': 'nVertices',
-                                             'data': ds.latVertex.values,
-                                             'attrs': {'units': 'radians'}},
-                               'lonVertex': {'dims': 'nVertices',
-                                             'data': ds.lonVertex.values,
-                                             'attrs': {'units': 'radians'}}}
-                self.dims = ['nVertices']
-            else:
-                # build coords
-                self.coords = {'latCell': {'dims': 'nCells',
-                                           'data': ds.latCell.values,
-                                           'attrs': {'units': 'radians'}},
-                               'lonCell': {'dims': 'nCells',
-                                           'data': ds.lonCell.values,
-                                           'attrs': {'units': 'radians'}}}
-                self.dims = ['nCells']
-            self.dimSize = [ds.dims[dim] for dim in self.dims]
-
-    def to_scrip(self, scripFileName):
-        """
-        Given an MPAS mesh file, create a SCRIP file based on the mesh.
-
-        Parameters
-        ----------
-        scripFileName : str
-            The path to which the SCRIP file should be written
-        """
-        if self.vertices:
-            raise ValueError('A SCRIP file won\'t work for remapping vertices')
-
-        inFile = netCDF4.Dataset(self.fileName, 'r')
-        outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
-
-        # Get info from input file
-        latCell = inFile.variables['latCell'][:]
-        lonCell = inFile.variables['lonCell'][:]
-        latVertex = inFile.variables['latVertex'][:]
-        lonVertex = inFile.variables['lonVertex'][:]
-        verticesOnCell = inFile.variables['verticesOnCell'][:]
-        nEdgesOnCell = inFile.variables['nEdgesOnCell'][:]
-        nCells = len(inFile.dimensions['nCells'])
-        maxVertices = len(inFile.dimensions['maxEdges'])
-        areaCell = inFile.variables['areaCell'][:]
-        sphereRadius = float(inFile.sphere_radius)
-
-        create_scrip(outFile, grid_size=nCells, grid_corners=maxVertices,
-                     grid_rank=1, units='radians', meshName=self.meshName)
-
-        grid_area = outFile.createVariable('grid_area', 'f8', ('grid_size',))
-        grid_area.units = 'radian^2'
-        # SCRIP uses square radians
-        grid_area[:] = areaCell[:] / (sphereRadius**2)
-
-        outFile.variables['grid_center_lat'][:] = latCell[:]
-        outFile.variables['grid_center_lon'][:] = lonCell[:]
-        outFile.variables['grid_dims'][:] = nCells
-        outFile.variables['grid_imask'][:] = 1
-
-        # grid corners:
-        grid_corner_lon = numpy.zeros((nCells, maxVertices))
-        grid_corner_lat = numpy.zeros((nCells, maxVertices))
-        for iVertex in range(maxVertices):
-            cellIndices = numpy.arange(nCells)
-            # repeat the last vertex wherever iVertex > nEdgesOnCell
-            localVertexIndices = numpy.minimum(nEdgesOnCell - 1, iVertex)
-            vertexIndices = verticesOnCell[cellIndices, localVertexIndices] - 1
-            grid_corner_lat[cellIndices, iVertex] = latVertex[vertexIndices]
-            grid_corner_lon[cellIndices, iVertex] = lonVertex[vertexIndices]
-
-        outFile.variables['grid_corner_lat'][:] = grid_corner_lat[:]
-        outFile.variables['grid_corner_lon'][:] = grid_corner_lon[:]
-
-        # Update history attribute of netCDF file
-        if hasattr(inFile, 'history'):
-            newhist = '\n'.join([getattr(inFile, 'history'),
-                                 ' '.join(sys.argv[:])])
-        else:
-            newhist = sys.argv[:]
-        setattr(outFile, 'history', newhist)
-
-        inFile.close()
-        outFile.close()
-
-    def to_esmf(self, esmfFileName):
-        """
-        Create an ESMF mesh file for the mesh
-
-        Parameters
-        ----------
-        esmfFileName : str
-            The path to which the ESMF mesh file should be written
-        """
-        with xarray.open_dataset(self.fileName) as ds:
-
-            nodeCount = ds.sizes['nVertices']
-            elementCount = ds.sizes['nCells']
-            coordDim = 2
-
-            nodeCoords = numpy.zeros((nodeCount, coordDim))
-            nodeCoords[:, 0] = ds.lonVertex.values
-            nodeCoords[:, 1] = ds.latVertex.values
-            centerCoords = numpy.zeros((elementCount, coordDim))
-            centerCoords[:, 0] = ds.lonCell.values
-            centerCoords[:, 1] = ds.latCell.values
-
-            elementConn = ds.verticesOnCell.values
-            elementConn[elementConn == nodeCount + 1] = -1
-
-            ds_out = xarray.Dataset()
-            ds_out['nodeCoords'] = (('nodeCount', 'coordDim'), nodeCoords)
-            ds_out.nodeCoords.attrs['units'] = 'radians'
-            ds_out['centerCoords'] = \
-                (('elementCount', 'coordDim'), centerCoords)
-            ds_out.centerCoords.attrs['units'] = 'radians'
-            ds_out['elementConn'] = \
-                (('elementCount', 'maxNodePElement'), elementConn)
-            ds_out.elementConn.attrs['start_index'] = 1
-            ds_out.elementConn.attrs['_FillValue'] = -1
-            ds_out['numElementConn'] = \
-                (('elementCount',), ds.nEdgesOnCell.values)
-            ds_out.attrs['gridType'] = 'unstructured mesh'
-            ds_out.attrs['version'] = '0.9'
-
-            ds_out.to_netcdf(esmfFileName, format=self.format,
-                             engine=self.engine)
+        super().__init__(fileName, meshName=meshName, vertices=vertices)

--- a/pyremap/descriptor/mpas_vertex_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_vertex_mesh_descriptor.py
@@ -9,14 +9,12 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/pyremap/main/LICENSE
 
-import sys
-
 import netCDF4
 import numpy as np
 import xarray as xr
 
 from pyremap.descriptor.mesh_descriptor import MeshDescriptor
-from pyremap.descriptor.utility import create_scrip
+from pyremap.descriptor.utility import add_history, create_scrip
 
 
 class MpasVertexMeshDescriptor(MeshDescriptor):
@@ -27,6 +25,9 @@ class MpasVertexMeshDescriptor(MeshDescriptor):
     ----------
     fileName : str
         The path of the file containing the MPAS mesh
+
+    history : str
+        The history attribute written to SCRIP files
     """
     def __init__(self, fileName, meshName=None):
         """
@@ -66,6 +67,8 @@ class MpasVertexMeshDescriptor(MeshDescriptor):
                                          'attrs': {'units': 'radians'}}}
             self.dims = ['nVertices']
             self.dimSize = [ds.dims[dim] for dim in self.dims]
+
+            self.history = add_history(ds=ds)
 
     def to_scrip(self, scripFileName):
         """
@@ -147,13 +150,7 @@ class MpasVertexMeshDescriptor(MeshDescriptor):
         outFile.variables['grid_corner_lat'][:] = grid_corner_lat[:]
         outFile.variables['grid_corner_lon'][:] = grid_corner_lon[:]
 
-        # Update history attribute of netCDF file
-        if hasattr(inFile, 'history'):
-            newhist = '\n'.join([getattr(inFile, 'history'),
-                                 ' '.join(sys.argv[:])])
-        else:
-            newhist = sys.argv[:]
-        setattr(outFile, 'history', newhist)
+        setattr(outFile, 'history', self.history)
 
         inFile.close()
         outFile.close()

--- a/pyremap/descriptor/mpas_vertex_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_vertex_mesh_descriptor.py
@@ -1,0 +1,159 @@
+# This software is open source software available under the BSD-3 license.
+#
+# Copyright (c) 2022 Triad National Security, LLC. All rights reserved.
+# Copyright (c) 2022 Lawrence Livermore National Security, LLC. All rights
+# reserved.
+# Copyright (c) 2022 UT-Battelle, LLC. All rights reserved.
+#
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at
+# https://raw.githubusercontent.com/MPAS-Dev/pyremap/main/LICENSE
+
+import sys
+
+import netCDF4
+import numpy as np
+import xarray as xr
+
+from pyremap.descriptor.mesh_descriptor import MeshDescriptor
+from pyremap.descriptor.utility import create_scrip
+
+
+class MpasVertexMeshDescriptor(MeshDescriptor):
+    """
+    A class for describing an MPAS vertex mesh
+
+    Attributes
+    ----------
+    fileName : str
+        The path of the file containing the MPAS mesh
+    """
+    def __init__(self, fileName, meshName=None):
+        """
+        Constructor stores the file name
+
+        Parameters
+        ----------
+        fileName : str
+            The path of the file containing the MPAS mesh
+
+        meshName : str, optional
+            The name of the MPAS mesh (e.g. ``'oEC60to30'`` or
+            ``'oRRS18to6'``).  If not provided, the data set in ``fileName``
+            must have a global attribute ``meshName`` that will be used
+            instead.
+        """
+        super().__init__()
+
+        with xr.open_dataset(fileName) as ds:
+
+            if meshName is None:
+                if 'meshName' not in ds.attrs:
+                    raise ValueError('No meshName provided or found in file.')
+                self.meshName = ds.attrs['meshName']
+            else:
+                self.meshName = meshName
+
+            self.fileName = fileName
+            self.regional = True
+
+            # build coords
+            self.coords = {'latVertex': {'dims': 'nVertices',
+                                         'data': ds.latVertex.values,
+                                         'attrs': {'units': 'radians'}},
+                           'lonVertex': {'dims': 'nVertices',
+                                         'data': ds.lonVertex.values,
+                                         'attrs': {'units': 'radians'}}}
+            self.dims = ['nVertices']
+            self.dimSize = [ds.dims[dim] for dim in self.dims]
+
+    def to_scrip(self, scripFileName):
+        """
+        Given an MPAS mesh file, create a SCRIP file based on the mesh.
+
+        Parameters
+        ----------
+        scripFileName : str
+            The path to which the SCRIP file should be written
+        """
+
+        inFile = netCDF4.Dataset(self.fileName, 'r')
+        outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
+
+        # Get info from input file
+        latCell = inFile.variables['latCell'][:]
+        lonCell = inFile.variables['lonCell'][:]
+        latVertex = inFile.variables['latVertex'][:]
+        lonVertex = inFile.variables['lonVertex'][:]
+        latEdge = inFile.variables['latEdge'][:]
+        lonEdge = inFile.variables['lonEdge'][:]
+        cellsOnVertex = inFile.variables['cellsOnVertex'][:]
+        edgesOnVertex = inFile.variables['edgesOnVertex'][:]
+        nVertices = len(inFile.dimensions['nVertices'])
+        vertexDegree = len(inFile.dimensions['vertexDegree'])
+        kiteAreasOnVertex = inFile.variables['kiteAreasOnVertex'][:]
+        sphereRadius = float(inFile.sphere_radius)
+
+        if vertexDegree != 3:
+            raise ValueError(f'MpasVertexMeshDescriptor does not support '
+                             f'vertexDegree {vertexDegree}')
+
+        create_scrip(outFile, grid_size=nVertices, grid_corners=6,
+                     grid_rank=1, units='radians', meshName=self.meshName)
+
+        validCellsOnVertex = np.zeros(nVertices, dtype=int)
+        vertexArea = np.zeros(nVertices)
+        for iCell in range(vertexDegree):
+            mask = cellsOnVertex[:, iCell] > 0
+            validCellsOnVertex[mask] = validCellsOnVertex[mask] + 1
+            vertexArea[mask] = (vertexArea[mask] +
+                                kiteAreasOnVertex[mask, iCell])
+
+        grid_area = outFile.createVariable('grid_area', 'f8', ('grid_size',))
+        grid_area.units = 'radian^2'
+        # SCRIP uses square radians
+        grid_area[:] = vertexArea[:] / (sphereRadius**2)
+
+        outFile.variables['grid_center_lat'][:] = latVertex[:]
+        outFile.variables['grid_center_lon'][:] = lonVertex[:]
+        outFile.variables['grid_dims'][:] = nVertices
+        outFile.variables['grid_imask'][:] = 1
+
+        # grid corners:
+        grid_corner_lon = np.zeros((nVertices, 6))
+        grid_corner_lat = np.zeros((nVertices, 6))
+
+        # start by filling the corners with the vertex lat and lon as the
+        # fallback
+        for iCorner in range(6):
+            grid_corner_lon[:, iCorner] = lonVertex
+            grid_corner_lat[:, iCorner] = latVertex
+
+        # if edges on vertex exist, replace even indices with their locations
+        for iEdge in range(3):
+            mask = edgesOnVertex[:, iEdge] > 0
+            edges = edgesOnVertex[mask, iEdge] - 1
+            grid_corner_lon[mask, 2 * iEdge] = lonEdge[edges]
+            grid_corner_lat[mask, 2 * iEdge] = latEdge[edges]
+
+        # similarly, if cells on vertex exist, replace odd indices with their
+        # locations
+        for iCell in range(3):
+            mask = cellsOnVertex[:, iCell] > 0
+            cells = cellsOnVertex[mask, iCell] - 1
+            grid_corner_lon[mask, 2 * iCell + 1] = lonCell[cells]
+            grid_corner_lat[mask, 2 * iCell + 1] = latCell[cells]
+
+        outFile.variables['grid_corner_lat'][:] = grid_corner_lat[:]
+        outFile.variables['grid_corner_lon'][:] = grid_corner_lon[:]
+
+        # Update history attribute of netCDF file
+        if hasattr(inFile, 'history'):
+            newhist = '\n'.join([getattr(inFile, 'history'),
+                                 ' '.join(sys.argv[:])])
+        else:
+            newhist = sys.argv[:]
+        setattr(outFile, 'history', newhist)
+
+        inFile.close()
+        outFile.close()

--- a/pyremap/descriptor/point_collection_descriptor.py
+++ b/pyremap/descriptor/point_collection_descriptor.py
@@ -9,14 +9,12 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/pyremap/main/LICENSE
 
-import sys
-
 import netCDF4
 import numpy
 import xarray
 
 from pyremap.descriptor.mesh_descriptor import MeshDescriptor
-from pyremap.descriptor.utility import create_scrip
+from pyremap.descriptor.utility import add_history, create_scrip
 
 
 class PointCollectionDescriptor(MeshDescriptor):
@@ -33,6 +31,9 @@ class PointCollectionDescriptor(MeshDescriptor):
 
     units : {'degrees', 'radians'}
         The units of ``lats`` and ``lons``
+
+    history : str
+        The history attribute written to SCRIP files
     """
 
     def __init__(self, lats, lons, collectionName, units='degrees',
@@ -74,6 +75,7 @@ class PointCollectionDescriptor(MeshDescriptor):
                                'attrs': {'units': units}}}
         self.dims = [outDimension]
         self.dimSize = [len(self.lat)]
+        self.history = add_history()
 
     def to_scrip(self, scripFileName):
         """
@@ -114,7 +116,7 @@ class PointCollectionDescriptor(MeshDescriptor):
         outFile.variables['grid_corner_lon'][:] = grid_corner_lon[:]
 
         # Update history attribute of netCDF file
-        setattr(outFile, 'history', ' '.join(sys.argv[:]))
+        setattr(outFile, 'history', self.history)
 
         outFile.close()
 

--- a/pyremap/descriptor/projection_grid_descriptor.py
+++ b/pyremap/descriptor/projection_grid_descriptor.py
@@ -9,8 +9,6 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/pyremap/main/LICENSE
 
-import sys
-
 import netCDF4
 import numpy
 import pyproj
@@ -18,6 +16,7 @@ import xarray
 
 from pyremap.descriptor.mesh_descriptor import MeshDescriptor
 from pyremap.descriptor.utility import (
+    add_history,
     create_scrip,
     interp_extrap_corner,
     unwrap_corners,
@@ -58,6 +57,9 @@ class ProjectionGridDescriptor(MeshDescriptor):
 
     yVarName : str
         The name of the y variable
+
+    history : str
+        The history attribute written to SCRIP files
     """
     def __init__(self, projection, meshName=None):
         """
@@ -84,6 +86,7 @@ class ProjectionGridDescriptor(MeshDescriptor):
         self.history = None
         self.xVarName = None
         self.yVarName = None
+        self.history = None
 
     @classmethod
     def read(cls, projection, fileName, meshName=None, xVarName='x',
@@ -130,12 +133,7 @@ class ProjectionGridDescriptor(MeshDescriptor):
         descriptor.xCorner = interp_extrap_corner(descriptor.x)
         descriptor.yCorner = interp_extrap_corner(descriptor.y)
 
-        # Update history attribute of netCDF file
-        if 'history' in ds.attrs:
-            descriptor.history = '\n'.join([ds.attrs['history'],
-                                            ' '.join(sys.argv[:])])
-        else:
-            descriptor.history = sys.argv[:]
+        descriptor.history = add_history(ds=ds)
         return descriptor
 
     @classmethod
@@ -172,7 +170,7 @@ class ProjectionGridDescriptor(MeshDescriptor):
         # interp/extrap corners
         descriptor.xCorner = interp_extrap_corner(descriptor.x)
         descriptor.yCorner = interp_extrap_corner(descriptor.y)
-        descriptor.history = sys.argv[:]
+        descriptor.history = add_history()
         return descriptor
 
     def to_scrip(self, scripFileName):

--- a/pyremap/descriptor/utility.py
+++ b/pyremap/descriptor/utility.py
@@ -9,6 +9,8 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/pyremap/main/LICENSE
 
+import sys
+
 import numpy
 
 
@@ -107,6 +109,17 @@ def unwrap_corners(inField):
 
 
 def round_res(res):
-    """Round the resoltuion to a reasonable number for grid names"""
+    """Round the resolution to a reasonable number for grid names"""
     rounded = numpy.round(res * 1000.) / 1000.
     return '{}'.format(rounded)
+
+
+def add_history(ds=None):
+    """Get the history attribute, possibly adding it to existing history"""
+    history = ' '.join(sys.argv[:])
+    if ds is not None and 'history' in ds.attrs:
+        prev_hist = ds.attrs['history']
+        if isinstance(prev_hist, numpy.ndarray):
+            prev_hist = '\n'.join(prev_hist)
+        history = '\n'.join([prev_hist, history])
+    return history


### PR DESCRIPTION
This merge adds separate mesh descriptors for MPAS cells and vertices.  This makes it possible to perform conservative remapping and to use SCRIP files from MPAS vertex meshes.

The `MpasMeshDescriptor` has been deprecated, as has the `vertices` argument to the constructor of `MpasCellMeshDescriptor` and `MpasMeshDescriptor`.

The `history` attribute is only written to SCRIP files if the `NETCDF4` format is used.  Otherwise, errors like:
```
OSError: array string attributes can only be written with NETCDF4
```
occur.

The examples have been updated (including a new one for an MPAS vertex mesh).

The version number has been bumped to 1.1.0 for a pending release.