### PR TITLE
Add capability to expand corners of SCRIP grid

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyremap" %}
-{% set version = "1.1.0" %}
+{% set version = "1.2.0" %}
 
 package:
   name: {{ name|lower }}

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -19,6 +19,7 @@ Documentation    On GitHub
 `v1.0.0`_         `1.0.0`_
 `v1.0.1`_         `1.0.1`_
 `v1.1.0`_         `1.1.0`_
+`v1.2.0`_         `1.2.0`_
 ================ ===============
 
 .. _`stable`: ../stable/index.html
@@ -36,6 +37,7 @@ Documentation    On GitHub
 .. _`v1.0.0`: ../1.0.0/index.html
 .. _`v1.0.1`: ../1.0.1/index.html
 .. _`v1.1.0`: ../1.1.0/index.html
+.. _`v1.2.0`: ../1.2.0/index.html
 .. _`main`: https://github.com/MPAS-Dev/pyremap/tree/main
 .. _`0.0.6`: https://github.com/MPAS-Dev/pyremap/tree/0.0.6
 .. _`0.0.7`: https://github.com/MPAS-Dev/pyremap/tree/0.0.7
@@ -51,3 +53,4 @@ Documentation    On GitHub
 .. _`1.0.0`: https://github.com/MPAS-Dev/pyremap/tree/1.0.0
 .. _`1.0.1`: https://github.com/MPAS-Dev/pyremap/tree/1.0.1
 .. _`1.1.0`: https://github.com/MPAS-Dev/pyremap/tree/1.1.0
+.. _`1.2.0`: https://github.com/MPAS-Dev/pyremap/tree/1.2.0

--- a/pyremap/__init__.py
+++ b/pyremap/__init__.py
@@ -12,5 +12,5 @@ from pyremap.descriptor import (
 from pyremap.polar import get_polar_descriptor, get_polar_descriptor_from_file
 from pyremap.remapper import Remapper
 
-__version_info__ = (1, 1, 0)
+__version_info__ = (1, 2, 0)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/pyremap/descriptor/lat_lon_2d_grid_descriptor.py
+++ b/pyremap/descriptor/lat_lon_2d_grid_descriptor.py
@@ -17,6 +17,7 @@ from pyremap.descriptor.mesh_descriptor import MeshDescriptor
 from pyremap.descriptor.utility import (
     add_history,
     create_scrip,
+    expand_scrip,
     interp_extrap_corners_2d,
     round_res,
     unwrap_corners,
@@ -122,7 +123,7 @@ class LatLon2DGridDescriptor(MeshDescriptor):
         descriptor.history = add_history(ds=ds)
         return descriptor
 
-    def to_scrip(self, scripFileName):
+    def to_scrip(self, scripFileName, expandDist=None, expandFactor=None):
         """
         Create a SCRIP file based on the grid.
 
@@ -130,6 +131,13 @@ class LatLon2DGridDescriptor(MeshDescriptor):
         ----------
         scripFileName : str
             The path to which the SCRIP file should be written
+
+        expandDist : float, optional
+            A distance in meters to expand each grid cell outward from the
+            center
+
+        expandFactor : float, optional
+            A factor by which to expand each grid cell outward from the center
         """
         outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
 
@@ -149,6 +157,9 @@ class LatLon2DGridDescriptor(MeshDescriptor):
             unwrap_corners(self.latCorner)
         outFile.variables['grid_corner_lon'][:] = \
             unwrap_corners(self.lonCorner)
+
+        if expandDist is not None or expandFactor is not None:
+            expand_scrip(outFile, expandDist, expandFactor)
 
         setattr(outFile, 'history', self.history)
 

--- a/pyremap/descriptor/lat_lon_grid_descriptor.py
+++ b/pyremap/descriptor/lat_lon_grid_descriptor.py
@@ -17,6 +17,7 @@ from pyremap.descriptor.mesh_descriptor import MeshDescriptor
 from pyremap.descriptor.utility import (
     add_history,
     create_scrip,
+    expand_scrip,
     interp_extrap_corner,
     round_res,
     unwrap_corners,
@@ -198,7 +199,7 @@ class LatLonGridDescriptor(MeshDescriptor):
         descriptor._set_coords('lat', 'lon', 'lat', 'lon')
         return descriptor
 
-    def to_scrip(self, scripFileName):
+    def to_scrip(self, scripFileName, expandDist=None, expandFactor=None):
         """
         Given a lat-lon grid file, create a SCRIP file based on the grid.
 
@@ -206,6 +207,13 @@ class LatLonGridDescriptor(MeshDescriptor):
         ----------
         scripFileName : str
             The path to which the SCRIP file should be written
+
+        expandDist : float, optional
+            A distance in meters to expand each grid cell outward from the
+            center
+
+        expandFactor : float, optional
+            A factor by which to expand each grid cell outward from the center
         """
         outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
 
@@ -227,6 +235,9 @@ class LatLonGridDescriptor(MeshDescriptor):
 
         outFile.variables['grid_corner_lat'][:] = unwrap_corners(LatCorner)
         outFile.variables['grid_corner_lon'][:] = unwrap_corners(LonCorner)
+
+        if expandDist is not None or expandFactor is not None:
+            expand_scrip(outFile, expandDist, expandFactor)
 
         setattr(outFile, 'history', self.history)
 

--- a/pyremap/descriptor/mesh_descriptor.py
+++ b/pyremap/descriptor/mesh_descriptor.py
@@ -61,7 +61,7 @@ class MeshDescriptor:
         self.format = 'NETCDF4'
         self.engine = None
 
-    def to_scrip(self, scripFileName):
+    def to_scrip(self, scripFileName, expandDist=None, expandFactor=None):
         """
         Subclasses should overload this method to write a SCRIP file based on
         the mesh.
@@ -70,6 +70,13 @@ class MeshDescriptor:
         ----------
         scripFileName : str
             The path to which the SCRIP file should be written
+
+        expandDist : float, optional
+            A distance in meters to expand each grid cell outward from the
+            center
+
+        expandFactor : float, optional
+            A factor by which to expand each grid cell outward from the center
         """
         raise NotImplementedError(
             'to_scrip is not implemented for this descriptor')

--- a/pyremap/descriptor/mpas_cell_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_cell_mesh_descriptor.py
@@ -16,7 +16,7 @@ import numpy
 import xarray
 
 from pyremap.descriptor.mesh_descriptor import MeshDescriptor
-from pyremap.descriptor.utility import add_history, create_scrip
+from pyremap.descriptor.utility import add_history, create_scrip, expand_scrip
 
 
 class MpasCellMeshDescriptor(MeshDescriptor):
@@ -98,7 +98,7 @@ class MpasCellMeshDescriptor(MeshDescriptor):
 
             self.history = add_history(ds=ds)
 
-    def to_scrip(self, scripFileName):
+    def to_scrip(self, scripFileName, expandDist=None, expandFactor=None):
         """
         Given an MPAS mesh file, create a SCRIP file based on the mesh.
 
@@ -106,6 +106,13 @@ class MpasCellMeshDescriptor(MeshDescriptor):
         ----------
         scripFileName : str
             The path to which the SCRIP file should be written
+
+        expandDist : float, optional
+            A distance in meters to expand each grid cell outward from the
+            center
+
+        expandFactor : float, optional
+            A factor by which to expand each grid cell outward from the center
         """
         if self.vertices:
             raise ValueError('A SCRIP file won\'t work for remapping vertices')
@@ -151,6 +158,9 @@ class MpasCellMeshDescriptor(MeshDescriptor):
 
         outFile.variables['grid_corner_lat'][:] = grid_corner_lat[:]
         outFile.variables['grid_corner_lon'][:] = grid_corner_lon[:]
+
+        if expandDist is not None or expandFactor is not None:
+            expand_scrip(outFile, expandDist, expandFactor)
 
         setattr(outFile, 'history', self.history)
 

--- a/pyremap/descriptor/mpas_edge_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_edge_mesh_descriptor.py
@@ -14,7 +14,7 @@ import numpy as np
 import xarray as xr
 
 from pyremap.descriptor.mesh_descriptor import MeshDescriptor
-from pyremap.descriptor.utility import add_history, create_scrip
+from pyremap.descriptor.utility import add_history, create_scrip, expand_scrip
 
 
 class MpasEdgeMeshDescriptor(MeshDescriptor):
@@ -70,7 +70,7 @@ class MpasEdgeMeshDescriptor(MeshDescriptor):
 
             self.history = add_history(ds=ds)
 
-    def to_scrip(self, scripFileName):
+    def to_scrip(self, scripFileName, expandDist=None, expandFactor=None):
         """
         Given an MPAS mesh file, create a SCRIP file based on the mesh.
 
@@ -78,6 +78,13 @@ class MpasEdgeMeshDescriptor(MeshDescriptor):
         ----------
         scripFileName : str
             The path to which the SCRIP file should be written
+
+        expandDist : float, optional
+            A distance in meters to expand each grid cell outward from the
+            center
+
+        expandFactor : float, optional
+            A factor by which to expand each grid cell outward from the center
         """
 
         inFile = netCDF4.Dataset(self.fileName, 'r')
@@ -145,6 +152,9 @@ class MpasEdgeMeshDescriptor(MeshDescriptor):
 
         outFile.variables['grid_corner_lat'][:] = grid_corner_lat[:]
         outFile.variables['grid_corner_lon'][:] = grid_corner_lon[:]
+
+        if expandDist is not None or expandFactor is not None:
+            expand_scrip(outFile, expandDist, expandFactor)
 
         setattr(outFile, 'history', self.history)
 

--- a/pyremap/descriptor/mpas_vertex_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_vertex_mesh_descriptor.py
@@ -14,7 +14,7 @@ import numpy as np
 import xarray as xr
 
 from pyremap.descriptor.mesh_descriptor import MeshDescriptor
-from pyremap.descriptor.utility import add_history, create_scrip
+from pyremap.descriptor.utility import add_history, create_scrip, expand_scrip
 
 
 class MpasVertexMeshDescriptor(MeshDescriptor):
@@ -70,7 +70,7 @@ class MpasVertexMeshDescriptor(MeshDescriptor):
 
             self.history = add_history(ds=ds)
 
-    def to_scrip(self, scripFileName):
+    def to_scrip(self, scripFileName, expandDist=None, expandFactor=None):
         """
         Given an MPAS mesh file, create a SCRIP file based on the mesh.
 
@@ -78,6 +78,13 @@ class MpasVertexMeshDescriptor(MeshDescriptor):
         ----------
         scripFileName : str
             The path to which the SCRIP file should be written
+
+        expandDist : float, optional
+            A distance in meters to expand each grid cell outward from the
+            center
+
+        expandFactor : float, optional
+            A factor by which to expand each grid cell outward from the center
         """
 
         inFile = netCDF4.Dataset(self.fileName, 'r')
@@ -149,6 +156,9 @@ class MpasVertexMeshDescriptor(MeshDescriptor):
 
         outFile.variables['grid_corner_lat'][:] = grid_corner_lat[:]
         outFile.variables['grid_corner_lon'][:] = grid_corner_lon[:]
+
+        if expandDist is not None or expandFactor is not None:
+            expand_scrip(outFile, expandDist, expandFactor)
 
         setattr(outFile, 'history', self.history)
 

--- a/pyremap/descriptor/point_collection_descriptor.py
+++ b/pyremap/descriptor/point_collection_descriptor.py
@@ -77,7 +77,7 @@ class PointCollectionDescriptor(MeshDescriptor):
         self.dimSize = [len(self.lat)]
         self.history = add_history()
 
-    def to_scrip(self, scripFileName):
+    def to_scrip(self, scripFileName, expandDist=None, expandFactor=None):
         """
         Given an MPAS mesh file, create a SCRIP file based on the mesh.
 
@@ -85,6 +85,13 @@ class PointCollectionDescriptor(MeshDescriptor):
         ----------
         scripFileName : str
             The path to which the SCRIP file should be written
+
+        expandDist : float, optional
+            A distance in meters to expand each grid cell outward from the
+            center
+
+        expandFactor : float, optional
+            A factor by which to expand each grid cell outward from the center
         """
 
         outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)

--- a/pyremap/descriptor/projection_grid_descriptor.py
+++ b/pyremap/descriptor/projection_grid_descriptor.py
@@ -18,6 +18,7 @@ from pyremap.descriptor.mesh_descriptor import MeshDescriptor
 from pyremap.descriptor.utility import (
     add_history,
     create_scrip,
+    expand_scrip,
     interp_extrap_corner,
     unwrap_corners,
 )
@@ -173,7 +174,7 @@ class ProjectionGridDescriptor(MeshDescriptor):
         descriptor.history = add_history()
         return descriptor
 
-    def to_scrip(self, scripFileName):
+    def to_scrip(self, scripFileName, expandDist=None, expandFactor=None):
         """
         Create a SCRIP file based on the grid and projection.
 
@@ -181,6 +182,13 @@ class ProjectionGridDescriptor(MeshDescriptor):
         ----------
         scripFileName : str
             The path to which the SCRIP file should be written
+
+        expandDist : float, optional
+            A distance in meters to expand each grid cell outward from the
+            center
+
+        expandFactor : float, optional
+            A factor by which to expand each grid cell outward from the center
         """
         outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
 
@@ -205,6 +213,9 @@ class ProjectionGridDescriptor(MeshDescriptor):
 
         outFile.variables['grid_corner_lat'][:] = unwrap_corners(LatCorner)
         outFile.variables['grid_corner_lon'][:] = unwrap_corners(LonCorner)
+
+        if expandDist is not None or expandFactor is not None:
+            expand_scrip(outFile, expandDist, expandFactor)
 
         setattr(outFile, 'history', self.history)
 

--- a/pyremap/descriptor/utility.py
+++ b/pyremap/descriptor/utility.py
@@ -12,6 +12,8 @@
 import sys
 
 import numpy
+import pyproj.enums
+from pyproj import Transformer
 
 
 def interp_extrap_corner(inField):
@@ -93,6 +95,82 @@ def create_scrip(outFile, grid_size, grid_corners, grid_rank, units,
     outFile.createVariable('grid_dims', 'i4', ('grid_rank',))
 
     outFile.meshName = meshName
+
+
+def expand_scrip(outFile, expandDist, expandFactor):
+    """
+    Given a SCRIP files, creates common variables and writes common values used
+    in various types of SCRIP files.
+
+    Parameters
+    ----------
+    outFile : file pointer
+        A SCRIP file opened in write mode
+
+    expandDist : float
+        A distance in meters to expand each grid cell outward from the
+        center
+
+    expandFactor : float
+        A factor by which to expand each grid cell outward from the center
+    """
+    grid_center_lat = outFile.variables['grid_center_lat'][:]
+    grid_center_lon = outFile.variables['grid_center_lon'][:]
+    grid_corner_lat = outFile.variables['grid_corner_lat'][:]
+    grid_corner_lon = outFile.variables['grid_corner_lon'][:]
+    grid_size = len(outFile.dimensions['grid_size'])
+    grid_corners = len(outFile.dimensions['grid_corners'])
+
+    radians = 'rad' in outFile.variables['grid_center_lat'].units
+
+    print(radians)
+
+    for index in range(grid_corners):
+        print(index)
+        print(grid_corner_lon[0, index], grid_corner_lat[0, index])
+
+    trans_lon_lat_to_xyz = Transformer.from_crs(4979, 4978, always_xy=True)
+    x_center, y_center, z_center = trans_lon_lat_to_xyz.transform(
+        grid_center_lon, grid_center_lat, numpy.zeros(grid_size),
+        radians=radians)
+
+    x_corner, y_corner, z_corner = trans_lon_lat_to_xyz.transform(
+        grid_corner_lon, grid_corner_lat,
+        numpy.zeros((grid_size, grid_corners)), radians=radians)
+
+    if expandFactor is None:
+        expandFactor = 1.
+
+    if expandDist is None:
+        expandDist = 0.
+
+    for index in range(grid_corners):
+        print(index)
+        print(x_corner[0, index], y_corner[0, index], z_corner[0, index])
+        print(x_center[0], y_center[0], z_center[0])
+        dx = x_corner[:, index] - x_center
+        dy = y_corner[:, index] - y_center
+        dz = z_corner[:, index] - z_center
+        print(dx[0], dy[0], dz[0])
+        dist = numpy.sqrt(dx**2 + dy**2 + dz**2)
+        print(dist[0])
+        factor = (expandFactor * dist + expandDist) / dist
+        print(factor[0])
+        x_corner[:, index] = factor * dx + x_center
+        y_corner[:, index] = factor * dy + y_center
+        z_corner[:, index] = factor * dz + z_center
+        print(x_corner[0, index], y_corner[0, index], z_corner[0, index])
+
+    grid_corner_lon, grid_corner_lat, _ = trans_lon_lat_to_xyz.transform(
+        x_corner, y_corner, z_corner, radians=radians,
+        direction=pyproj.enums.TransformDirection.INVERSE)
+
+    for index in range(grid_corners):
+        print(index)
+        print(grid_corner_lon[0, index], grid_corner_lat[0, index])
+
+    outFile.variables['grid_corner_lat'][:] = grid_corner_lat[:]
+    outFile.variables['grid_corner_lon'][:] = grid_corner_lon[:]
 
 
 def unwrap_corners(inField):


### PR DESCRIPTION
This capability can be used on the destination mesh as part of conservative remapping in order to provide smoothing as part of the remapping process.  The smoothing can either be over a fixed distance (`expandDist` in meters) or by a factor (`expandFactor`).