### PR TITLE
Allow ndarrays for expanding cells in SCRIP files

### DIFF
--- a/pyremap/descriptor/lat_lon_2d_grid_descriptor.py
+++ b/pyremap/descriptor/lat_lon_2d_grid_descriptor.py
@@ -132,12 +132,13 @@ class LatLon2DGridDescriptor(MeshDescriptor):
         scripFileName : str
             The path to which the SCRIP file should be written
 
-        expandDist : float, optional
+        expandDist : float or numpy.ndarray, optional
             A distance in meters to expand each grid cell outward from the
-            center
+            center.  If a ``numpy.ndarray``, one value per cell.
 
-        expandFactor : float, optional
-            A factor by which to expand each grid cell outward from the center
+        expandFactor : float or numpy.ndarray, optional
+            A factor by which to expand each grid cell outward from the center.
+            If a ``numpy.ndarray``, one value per cell.
         """
         outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
 

--- a/pyremap/descriptor/lat_lon_grid_descriptor.py
+++ b/pyremap/descriptor/lat_lon_grid_descriptor.py
@@ -208,12 +208,13 @@ class LatLonGridDescriptor(MeshDescriptor):
         scripFileName : str
             The path to which the SCRIP file should be written
 
-        expandDist : float, optional
+        expandDist : float or numpy.ndarray, optional
             A distance in meters to expand each grid cell outward from the
-            center
+            center.  If a ``numpy.ndarray``, one value per cell.
 
-        expandFactor : float, optional
-            A factor by which to expand each grid cell outward from the center
+        expandFactor : float or numpy.ndarray, optional
+            A factor by which to expand each grid cell outward from the center.
+            If a ``numpy.ndarray``, one value per cell.
         """
         outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
 

--- a/pyremap/descriptor/mesh_descriptor.py
+++ b/pyremap/descriptor/mesh_descriptor.py
@@ -71,12 +71,13 @@ class MeshDescriptor:
         scripFileName : str
             The path to which the SCRIP file should be written
 
-        expandDist : float, optional
+        expandDist : float or numpy.ndarray, optional
             A distance in meters to expand each grid cell outward from the
-            center
+            center.  If a ``numpy.ndarray``, one value per cell.
 
-        expandFactor : float, optional
-            A factor by which to expand each grid cell outward from the center
+        expandFactor : float or numpy.ndarray, optional
+            A factor by which to expand each grid cell outward from the center.
+            If a ``numpy.ndarray``, one value per cell.
         """
         raise NotImplementedError(
             'to_scrip is not implemented for this descriptor')

--- a/pyremap/descriptor/mpas_cell_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_cell_mesh_descriptor.py
@@ -107,12 +107,13 @@ class MpasCellMeshDescriptor(MeshDescriptor):
         scripFileName : str
             The path to which the SCRIP file should be written
 
-        expandDist : float, optional
+        expandDist : float or numpy.ndarray, optional
             A distance in meters to expand each grid cell outward from the
-            center
+            center.  If a ``numpy.ndarray``, one value per cell.
 
-        expandFactor : float, optional
-            A factor by which to expand each grid cell outward from the center
+        expandFactor : float or numpy.ndarray, optional
+            A factor by which to expand each grid cell outward from the center.
+            If a ``numpy.ndarray``, one value per cell.
         """
         if self.vertices:
             raise ValueError('A SCRIP file won\'t work for remapping vertices')

--- a/pyremap/descriptor/mpas_edge_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_edge_mesh_descriptor.py
@@ -79,12 +79,13 @@ class MpasEdgeMeshDescriptor(MeshDescriptor):
         scripFileName : str
             The path to which the SCRIP file should be written
 
-        expandDist : float, optional
+        expandDist : float or numpy.ndarray, optional
             A distance in meters to expand each grid cell outward from the
-            center
+            center.  If a ``numpy.ndarray``, one value per cell.
 
-        expandFactor : float, optional
-            A factor by which to expand each grid cell outward from the center
+        expandFactor : float or numpy.ndarray, optional
+            A factor by which to expand each grid cell outward from the center.
+            If a ``numpy.ndarray``, one value per cell.
         """
 
         inFile = netCDF4.Dataset(self.fileName, 'r')

--- a/pyremap/descriptor/mpas_vertex_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_vertex_mesh_descriptor.py
@@ -79,12 +79,13 @@ class MpasVertexMeshDescriptor(MeshDescriptor):
         scripFileName : str
             The path to which the SCRIP file should be written
 
-        expandDist : float, optional
+        expandDist : float or numpy.ndarray, optional
             A distance in meters to expand each grid cell outward from the
-            center
+            center.  If a ``numpy.ndarray``, one value per cell.
 
-        expandFactor : float, optional
-            A factor by which to expand each grid cell outward from the center
+        expandFactor : float or numpy.ndarray, optional
+            A factor by which to expand each grid cell outward from the center.
+            If a ``numpy.ndarray``, one value per cell.
         """
 
         inFile = netCDF4.Dataset(self.fileName, 'r')

--- a/pyremap/descriptor/point_collection_descriptor.py
+++ b/pyremap/descriptor/point_collection_descriptor.py
@@ -86,12 +86,13 @@ class PointCollectionDescriptor(MeshDescriptor):
         scripFileName : str
             The path to which the SCRIP file should be written
 
-        expandDist : float, optional
+        expandDist : float or numpy.ndarray, optional
             A distance in meters to expand each grid cell outward from the
-            center
+            center.  If a ``numpy.ndarray``, one value per cell.
 
-        expandFactor : float, optional
-            A factor by which to expand each grid cell outward from the center
+        expandFactor : float or numpy.ndarray, optional
+            A factor by which to expand each grid cell outward from the center.
+            If a ``numpy.ndarray``, one value per cell.
         """
 
         outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)

--- a/pyremap/descriptor/projection_grid_descriptor.py
+++ b/pyremap/descriptor/projection_grid_descriptor.py
@@ -183,12 +183,13 @@ class ProjectionGridDescriptor(MeshDescriptor):
         scripFileName : str
             The path to which the SCRIP file should be written
 
-        expandDist : float, optional
+        expandDist : float or numpy.ndarray, optional
             A distance in meters to expand each grid cell outward from the
-            center
+            center.  If a ``numpy.ndarray``, one value per cell.
 
-        expandFactor : float, optional
-            A factor by which to expand each grid cell outward from the center
+        expandFactor : float or numpy.ndarray, optional
+            A factor by which to expand each grid cell outward from the center.
+            If a ``numpy.ndarray``, one value per cell.
         """
         outFile = netCDF4.Dataset(scripFileName, 'w', format=self.format)
 

--- a/pyremap/descriptor/utility.py
+++ b/pyremap/descriptor/utility.py
@@ -107,12 +107,13 @@ def expand_scrip(outFile, expandDist, expandFactor):
     outFile : file pointer
         A SCRIP file opened in write mode
 
-    expandDist : float
+    expandDist : float or numpy.ndarray
         A distance in meters to expand each grid cell outward from the
-        center
+        center.  If a ``numpy.ndarray``, one value per cell.
 
-    expandFactor : float
-        A factor by which to expand each grid cell outward from the center
+    expandFactor : float or numpy.ndarray
+        A factor by which to expand each grid cell outward from the center.
+        If a ``numpy.ndarray``, one value per cell.
     """
     grid_center_lat = outFile.variables['grid_center_lat'][:]
     grid_center_lon = outFile.variables['grid_center_lon'][:]

--- a/pyremap/remapper.py
+++ b/pyremap/remapper.py
@@ -143,15 +143,17 @@ class Remapper(object):
         include_logs : bool, optional
             Whether to include log files from ``ESMF_RegridWeightGen``
 
-        expandDist : float, optional
+        expandDist : float or numpy.ndarray, optional
             A distance in meters to expand each cell of the destination mesh
             outward from the center.  This can be used to smooth fields on
-            the destination grid.
+            the destination grid.  If a ``numpy.ndarray``, one value per cell
+            on the destination mesh.
 
-        expandFactor : float, optional
+        expandFactor : float or numpy.ndarray, optional
             A factor by which to expand each cell of the destination mesh
             outward from the center.  This can be used to smooth fields on
-            the destination grid.
+            the destination grid.  If a ``numpy.ndarray``, one value per cell
+            on the destination mesh.
 
         Raises
         ------


### PR DESCRIPTION
This is just an update in the docstrings, since the code will already work if an ndarray is passed for `expandDist` or `expandFactor`