### PR TITLE
Add `esmf_build_map()` method and reorganize 

### DIFF
--- a/examples/make_mpas_to_Antarctic_stereo_mapping.py
+++ b/examples/make_mpas_to_Antarctic_stereo_mapping.py
@@ -44,7 +44,7 @@ mappingFileName = f'map_{inGridName}_to_{outGridName}_bilinear.nc'
 remapper = Remapper(inDescriptor, outDescriptor, mappingFileName)
 
 # conservative remapping with 4 MPI tasks (using mpirun)
-remapper.build_mapping_file(method='bilinear', mpiTasks=4)
+remapper.esmf_build_map(method='bilinear', mpi_tasks=4)
 
 # select the SST at the initial time as an example data set
 srcFileName = f'temp_{inGridName}.nc'

--- a/examples/make_mpas_to_lat_lon_mapping.py
+++ b/examples/make_mpas_to_lat_lon_mapping.py
@@ -42,7 +42,7 @@ mappingFileName = f'map_{inGridName}_to_{outGridName}_bilinear.nc'
 
 remapper = Remapper(inDescriptor, outDescriptor, mappingFileName)
 
-remapper.build_mapping_file(method='bilinear', mpiTasks=1)
+remapper.esmf_build_map(method='bilinear', mpi_tasks=1)
 
 outFileName = f'temp_{outGridName}.nc'
 ds = xarray.open_dataset(inGridFileName)

--- a/examples/make_mpas_vertex_to_Antarctic_stereo_mapping.py
+++ b/examples/make_mpas_vertex_to_Antarctic_stereo_mapping.py
@@ -45,8 +45,8 @@ mappingFileName = f'map_{inGridName}_vertex_to_{outGridName}_conserve.nc'
 remapper = Remapper(inDescriptor, outDescriptor, mappingFileName)
 
 # conservative remapping with 4 MPI tasks (using mpirun)
-remapper.build_mapping_file(method='conserve', mpiTasks=4,
-                            esmf_parallel_exec='mpirun', include_logs=True)
+remapper.esmf_build_map(method='conserve', mpi_tasks=4,
+                        parallel_exec='mpirun', include_logs=True)
 
 # select the SST at the initial time as an example data set
 srcFileName = f'vertex_id_{inGridName}.nc'

--- a/examples/remap_stereographic.py
+++ b/examples/remap_stereographic.py
@@ -39,9 +39,9 @@ dsIn = xarray.open_dataset(args.inFileName)
 
 x = dsIn.x.values
 y = dsIn.y.values
-dx = int((x[1]-x[0])/1000.)
-Lx = int((x[-1] - x[0])/1000.)
-Ly = int((y[-1] - y[0])/1000.)
+dx = int((x[1] - x[0]) / 1000.)
+Lx = int((x[-1] - x[0]) / 1000.)
+Ly = int((y[-1] - y[0]) / 1000.)
 
 inMeshName = f'{Lx}x{Ly}km_{dx}km_Antarctic_stereo'
 
@@ -49,13 +49,13 @@ projection = get_antarctic_stereographic_projection()
 
 inDescriptor = ProjectionGridDescriptor.create(projection, x, y, inMeshName)
 
-outRes = args.resolution*1e3
+outRes = args.resolution * 1e3
 
-nxOut = int((x[-1] - x[0])/outRes + 0.5) + 1
-nyOut = int((y[-1] - y[0])/outRes + 0.5) + 1
+nxOut = int((x[-1] - x[0]) / outRes + 0.5) + 1
+nyOut = int((y[-1] - y[0]) / outRes + 0.5) + 1
 
-xOut = x[0] + outRes*numpy.arange(nxOut)
-yOut = y[0] + outRes*numpy.arange(nyOut)
+xOut = x[0] + outRes * numpy.arange(nxOut)
+yOut = y[0] + outRes * numpy.arange(nyOut)
 
 
 outMeshName = f'{Lx}x{Ly}km_{args.resolution}km_Antarctic_stereo'
@@ -67,7 +67,7 @@ mappingFileName = f'map_{inMeshName}_to_{outMeshName}_{args.method}.nc'
 
 remapper = Remapper(inDescriptor, outDescriptor, mappingFileName)
 
-remapper.build_mapping_file(method=args.method, mpiTasks=args.mpiTasks)
+remapper.esmf_build_map(method=args.method, mpi_tasks=args.mpiTasks)
 
 dsOut = remapper.remap(dsIn, renormalizationThreshold=0.01)
 dsOut.to_netcdf(args.outFileName)


### PR DESCRIPTION
This merge deprecates the `build_mapping_file()` method, which is replaced by `esmf_build_map()`.  The contents of `build_mapping_file()` are reorganized into helper methods.  The examples have been updated accordingly.