### PR TITLE
Tweak behaviors in build workflow

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -10,14 +10,14 @@ on:
   workflow_dispatch:
 
 env:
-  CANCEL_OTHERS: true
+  CANCEL_OTHERS: false
   PATHS_IGNORE: '["**/README.md", "**/docs/**", "**/examples/**"]'
 
 jobs:
   pre-commit-hooks:
     name: lint with pre-commit
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
@@ -79,11 +79,9 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: "pyremap_ci"
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
-          channels: conda-forge,defaults
+          channels: conda-forge
           channel-priority: strict
           auto-update-conda: true
           # IMPORTANT: This needs to be set for caching to work properly!
@@ -93,7 +91,7 @@ jobs:
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install pyremap
         run: |
-          mamba install --file dev-spec.txt
+          conda install --file dev-spec.txt
           python -m pip install .
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}


### PR DESCRIPTION
In this PR I've tweaked the behaviors in the build workflow to fix a few issues:
1. `cancel_others` is now set to false by default, which should make it easier to decipher if a bug is isolated to a specific version of python via CI
2. All references to `mamba`/`mambaforge` have been removed and/or changed to `conda`
3. The `defaults` channel has been removed as we can now exclusively use `conda-forge`
4. The timeout for the `pre-commit` job has been upped to 5 minutes