### PR TITLE
Add dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "xylar"
+    reviewers:
+      - "xylar"
+      - "altheaden"
+


### PR DESCRIPTION
In this PR, I am adding the dependabot workflow to the CI actions. Dependabot automatically locates dependencies with outdated versions and attempts to generate PRs to update them. We currently have Dependabot set up in Mache, Polaris and Compass.