### PR TITLE
Add flags to `pip install` command

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -92,7 +92,7 @@ jobs:
           conda create -n pyremap_dev --file dev-spec.txt \
               python=${{ matrix.python-version }}
           conda activate pyremap_dev
-          python -m pip install .
+          python -m pip install -vv --no-deps --no-build-isolation .
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Run Tests

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 conda create -y -n pyremap --file dev-spec.txt
 conda activate pyremap
-python -m pip install -e .
+python -m pip install --no-deps --no-build-isolation -e .
 ```
 
 ## Examples

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install -vv --no-deps --no-build-isolation .
   noarch: python
 
 requirements:


### PR DESCRIPTION
In this PR I added a few flags to the `python -m pip install [-e] .` command. The flags are:
* `-vv` indicates very verbose output. This flag is used during the CI runs to help with debugging.
* `--no-deps` indicates that pip should not install runtime dependencies from PyPi.
* `--no-build-isolation` indicates that pip should not install build time dependencies from PyPi.