### PR TITLE
Add CI workflow to automatically update pre-commit and its dependencies

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -52,6 +52,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        fail-fast: false
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -1,0 +1,68 @@
+name: Pre-commit auto-update
+
+on:
+  schedule:
+    # Cron syntax:
+    # 1. Entry: Minute when the process will be started [0-60]
+    # 2. Entry: Hour when the process will be started [0-23]
+    # 3. Entry: Day of the month when the process will be started [1-28/29/30/31]
+    # 4. Entry: Month of the year when the process will be started [1-12]
+    # 5. Entry: Weekday when the process will be started [0-6] [0 is Sunday]
+    - cron: '0 8 * * 3'
+
+env:
+  UP_TO_DATE: false
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Apply and commit updates
+        run: |
+          git clone https://github.com/MPAS-Dev/pyremap.git update-pre-commit-deps
+          cd update-pre-commit-deps
+          # Configure git using GitHub Actions credentials.
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git checkout -b update-pre-commit-deps
+          pre-commit autoupdate
+          git add .
+          # Either there are changes, in which case we commit them, or there are no changes,
+          # in which case we can skip the push & pr-create jobs
+          git commit -m "Update pre-commit dependencies" \
+          || ( echo "UP_TO_DATE=true" >> "$GITHUB_ENV")
+
+      - name: Push Changes
+        if: ${{ env.UP_TO_DATE == 'false' }}
+        uses: ad-m/github-push-action@master
+        with:
+          branch: update-pre-commit-deps
+          directory: update-pre-commit-deps
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          force: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Make PR and add reviewers and labels
+        if: ${{ env.UP_TO_DATE == 'false' }}
+        run: |
+          cd update-pre-commit-deps
+          gh pr create \
+          --title "Update pre-commit and its dependencies" \
+          --body "This PR was auto-generated to update pre-commit and its dependencies." \
+          --head update-pre-commit-deps \
+          --reviewer altheaden,xylar \
+          --label ci
+        env:
+          GH_TOKEN: ${{ github.token }}
+


### PR DESCRIPTION
This adds a GitHub actions workflow that will run the `pre-commit autoupdate` command to update `pre-commit` and its dependencies. The workflow is set to run weekly on Wednesdays and should automatically create a pull request with the updates when they are available. 