### PR TITLE
Use separate conda cache directories in CI

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -78,7 +78,7 @@ jobs:
           # Increase this value to reset cache if dev-spec.txt has not changed in the workflow
           CACHE_NUMBER: 0
         with:
-          path: ~/conda_pkgs_dir
+          path: ~/conda_pkgs_dir_py${{ matrix.python-version }}
           key:
             ${{ runner.os }}-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('dev-spec.txt') }}

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   UP_TO_DATE: false
+  PYTHON_VERSION: "3.10"
 
 jobs:
   auto-update:
@@ -22,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install pre-commit
         run: pip install pre-commit


### PR DESCRIPTION
This PR updates the build workflow to use separate directories for each python version for conda caching. Issues with this seem to have been crashing CI runs lately.

I also set the python version in the pre-commit update workflow to a variable, `PYTHON_VERSION`, to clean it up a little.