### PR TITLE
Add a logger to to the build_map() method

### DIFF
--- a/pyremap/remapper/build_map.py
+++ b/pyremap/remapper/build_map.py
@@ -5,9 +5,16 @@ from pyremap.remapper.setup import _setup_remapper
 from pyremap.utility import check_call
 
 
-def _build_map(remapper):
+def _build_map(remapper, logger=None):
     """
     Make the mapping file
+
+    Parameters
+    ----------
+    remapper : pyremap.remapper.MpasRemapper
+        The remapper object to use to create the mapping file
+    logger : logging.Logger, optional
+        A logger to which ncclimo output should be redirected
     """
     _setup_remapper(remapper)
     map_tool = remapper.map_tool
@@ -52,10 +59,10 @@ def _build_map(remapper):
     elif map_tool == 'moab':
         moab_path = remapper.moab_path
         src_scrip_filename = _moab_partition_scrip_file(
-            remapper, src_scrip_filename, moab_path
+            remapper, src_scrip_filename, moab_path, logger
         )
         dst_scrip_filename = _moab_partition_scrip_file(
-            remapper, dst_scrip_filename, moab_path
+            remapper, dst_scrip_filename, moab_path, logger
         )
         args = _moab_build_map_args(
             remapper, src_scrip_filename, dst_scrip_filename
@@ -80,13 +87,13 @@ def _build_map(remapper):
                 f'Valid values are "mpirun" or "srun".'
             )
 
-    check_call(args)
+    check_call(args, logger=logger)
 
     if tempobj is not None:
         tempobj.cleanup()
 
 
-def _moab_partition_scrip_file(remapper, in_filename, moab_path):
+def _moab_partition_scrip_file(remapper, in_filename, moab_path, logger):
     """
     Partition SCRIP file for parallel mbtempest use
     """
@@ -111,7 +118,7 @@ def _moab_partition_scrip_file(remapper, in_filename, moab_path):
         in_filename,
         h5m_filename,
     ]
-    check_call(args)
+    check_call(args, logger=logger)
 
     # Partition source SCRIP
     args = [
@@ -122,7 +129,7 @@ def _moab_partition_scrip_file(remapper, in_filename, moab_path):
         h5m_filename,
         h5m_part_filename,
     ]
-    check_call(args)
+    check_call(args, logger=logger)
 
     print('  Done.')
 

--- a/pyremap/remapper/remapper.py
+++ b/pyremap/remapper/remapper.py
@@ -380,11 +380,16 @@ class Remapper:
         dst['mpas_mesh_type'] = mesh_type
         self.dst_grid_info = dst
 
-    def build_map(self):
+    def build_map(self, logger=None):
         """
         Make the mapping file
+
+        Parameters
+        ----------
+        logger : logging.Logger, optional
+            A logger to which ncclimo output should be redirected
         """
-        _build_map(self)
+        _build_map(self, logger=logger)
 
     def ncremap(
         self,
@@ -423,7 +428,7 @@ class Remapper:
         renormalize : float, optional
             A threshold to use to renormalize the data
 
-        logger : ``logging.Logger``, optional
+        logger : logging.Logger, optional
             A logger to which ncclimo output should be redirected
 
         replace_mpas_fill : bool, optional


### PR DESCRIPTION
This pull request introduces support for logging in the `pyremap` package, specifically in the `build_map` and `moab_partition_scrip_file` functions. The changes allow optional logging of output to a specified logger, improving the traceability and debugging capabilities of the code.

Enhancements to logging:

* [`pyremap/remapper/build_map.py`](diffhunk://#diff-129a160e000bfecfdac3efea475ddcf99d3251f6f295871c3c0cc08f3c5bcdf6L8-R17): Modified the `_build_map` function to accept an optional `logger` parameter and pass it to `check_call` and `_moab_partition_scrip_file` calls. [[1]](diffhunk://#diff-129a160e000bfecfdac3efea475ddcf99d3251f6f295871c3c0cc08f3c5bcdf6L8-R17) [[2]](diffhunk://#diff-129a160e000bfecfdac3efea475ddcf99d3251f6f295871c3c0cc08f3c5bcdf6L55-R65) [[3]](diffhunk://#diff-129a160e000bfecfdac3efea475ddcf99d3251f6f295871c3c0cc08f3c5bcdf6L83-R96)
* [`pyremap/remapper/build_map.py`](diffhunk://#diff-129a160e000bfecfdac3efea475ddcf99d3251f6f295871c3c0cc08f3c5bcdf6L114-R121): Updated the `_moab_partition_scrip_file` function to accept an optional `logger` parameter and pass it to `check_call` calls. [[1]](diffhunk://#diff-129a160e000bfecfdac3efea475ddcf99d3251f6f295871c3c0cc08f3c5bcdf6L114-R121) [[2]](diffhunk://#diff-129a160e000bfecfdac3efea475ddcf99d3251f6f295871c3c0cc08f3c5bcdf6L125-R132)

Support for logger parameter in remapper methods:

* [`pyremap/remapper/remapper.py`](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edL383-R392): Updated the `build_map` method to accept an optional `logger` parameter and pass it to the `_build_map` function.
* [`pyremap/remapper/remapper.py`](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edL426-R431): Corrected the docstring format for the `logger` parameter in the `ncremap` method.