### PR TITLE
Add more optional arguments to the remapper init

### DIFF
--- a/pyremap/remapper/remapper.py
+++ b/pyremap/remapper/remapper.py
@@ -78,6 +78,10 @@ class Remapper:
         ntasks=1,
         map_filename=None,
         method='bilinear',
+        src_descriptor=None,
+        dst_descriptor=None,
+        map_tool='esmf',
+        parallel_exec='mpirun',
         use_tmp=True,
     ):
         """
@@ -95,6 +99,20 @@ class Remapper:
         method : {'bilinear', 'neareststod', 'conserve'}, optional
             The method of interpolation used
 
+        src_descriptor: pyremap.descriptor.MeshDescriptor, optional
+            The source mesh descriptor
+
+        dst_descriptor: pyremap.descriptor.MeshDescriptor, optional
+            The destination mesh descriptor
+
+        map_tool : {'esmf', 'moab'}, optional
+            The tool to use for building the mapping file.  The default is
+            ``esmf``.
+
+        parallel_exec : {'mpirun', 'srun'}, optional
+            The command to use for running the mapping tool.  The default is
+            ``mpirun``.
+
         use_tmp : bool, optional
             If True, use a temporary directory for the SCRIP files.  The
             default is False, which means the SCRIP files will be created in
@@ -111,12 +129,12 @@ class Remapper:
         self.src_scrip_filename = 'src_mesh.nc'
         self.dst_scrip_filename = 'dst_mesh.nc'
         self.format = 'NETCDF3_64BIT_DATA'
-        self.src_descriptor = None
-        self.dst_descriptor = None
-        self.map_tool = 'esmf'
+        self.src_descriptor = src_descriptor
+        self.dst_descriptor = dst_descriptor
+        self.map_tool = map_tool
         self.esmf_path = None
         self.moab_path = None
-        self.parallel_exec = 'mpirun'
+        self.parallel_exec = parallel_exec
         self._ds_map = None
         self._matrix = None
 


### PR DESCRIPTION
This pull request includes several enhancements to the `__init__` method in the `pyremap/remapper/remapper.py` file. The most important changes involve adding new parameters to improve flexibility and functionality.

Enhancements to `__init__` method:

* Added `src_descriptor` and `dst_descriptor` parameters to allow specifying source and destination mesh descriptors. [[1]](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edR81-R84) [[2]](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edR102-R115) [[3]](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edL114-R137)
* Introduced `map_tool` parameter to specify the tool used for building the mapping file, with a default value of `esmf`. [[1]](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edR81-R84) [[2]](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edR102-R115) [[3]](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edL114-R137)
* Added `parallel_exec` parameter to define the command for running the mapping tool, defaulting to `mpirun`. [[1]](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edR81-R84) [[2]](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edR102-R115) [[3]](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edL114-R137)