### PR TITLE
Fixes to docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -196,5 +196,5 @@ html_sidebars = {
 }
 
 html_context = {
-    "current_version": os.getenv("DOC_VERSION", "main"),
+    "current_version": os.getenv("DOCS_VERSION", "main"),
 }

--- a/docs/developer_guide/generate_preview_docs.md
+++ b/docs/developer_guide/generate_preview_docs.md
@@ -20,7 +20,7 @@ Ensure you have the following installed:
 To build the documentation, run the following command:
 ```bash
 cd docs
-DOC_VERSION=main make versioned-html
+DOCS_VERSION=main make versioned-html
 ```
 This will generate the static site in the `_build/html/main` directory.
 

--- a/docs/generate_versions_json.py
+++ b/docs/generate_versions_json.py
@@ -2,10 +2,21 @@
 import argparse
 import json
 import os
+import re
+
+
+def version_key(name):
+    """Key function for sorting versions."""
+    match = re.match(r'^(\d+)\.(\d+)\.(\d+)$', name)
+    if match:
+        # Sort by major, minor, patch
+        return tuple(map(int, match.groups()))
+    return ()
+
 
 # Mode: local or production
 parser = argparse.ArgumentParser(
-    description='Generate versions.json for pyremap documentation.')
+    description='Generate versions.json for MPAS-Tools documentation.')
 parser.add_argument(
     '--local',
     action='store_true',
@@ -19,9 +30,28 @@ shared_dir = os.path.join(base_dir, 'shared')
 entries = []
 
 if not os.path.exists(base_dir) or not os.listdir(base_dir):
-    raise FileNotFoundError(f"Base directory '{base_dir}' does not exist or is empty.")
+    raise FileNotFoundError(
+        f"Base directory '{base_dir}' does not exist or is empty.")
 
-versions = sorted(os.listdir(base_dir), reverse=True)
+versions = os.listdir(base_dir)
+numeric_versions = []
+non_numeric_versions = []
+
+for version in versions:
+    # Check if it matches version pattern
+    if re.match(r'^\d+\.\d+\.\d+$', version):
+        numeric_versions.append(version)
+    else:
+        non_numeric_versions.append(version)
+
+# Sort numeric versions by major, minor, patch in descending order
+numeric_versions.sort(key=version_key, reverse=True)
+# Sort non-numeric versions alphabetically
+non_numeric_versions.sort()
+
+# Combine the sorted lists
+versions = non_numeric_versions + numeric_versions
+
 if 'main' in versions:
     versions.insert(0, versions.pop(versions.index('main')))
 


### PR DESCRIPTION
This pull request includes several changes to the documentation configuration and generation scripts. The most important changes include updating environment variable names, adding a version sorting function, and modifying how versions are handled and sorted.

### Environment variable updates:
* [`docs/conf.py`](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L199-R199): Changed the environment variable from `DOC_VERSION` to `DOCS_VERSION`.
* [`docs/developer_guide/generate_preview_docs.md`](diffhunk://#diff-648006b6dd33cf4c41be0db4bf35ac5dbc466cc3a649a1c7dd23410c13303ac4L23-R23): Updated the command to use `DOCS_VERSION` instead of `DOC_VERSION`.

### Version sorting and handling improvements:
* [`docs/generate_versions_json.py`](diffhunk://#diff-3e2d764e8859559fd12559ed8ef85bbd3f9ecde57e1c3eb1493a8f76e2ca83baR5-R19): Added a `version_key` function for sorting versions by major, minor, and patch numbers.
* [`docs/generate_versions_json.py`](diffhunk://#diff-3e2d764e8859559fd12559ed8ef85bbd3f9ecde57e1c3eb1493a8f76e2ca83baL22-L24): Modified the script to separate numeric and non-numeric versions, sort them accordingly, and then combine the sorted lists.