### PR TITLE
A clean-up PR

### DIFF
--- a/pyremap/descriptor/mpas_cell_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_cell_mesh_descriptor.py
@@ -127,7 +127,12 @@ class MpasCellMeshDescriptor(MeshDescriptor):
 
         ds_out = xr.Dataset()
 
-        ds_out['grid_area'] = (('grid_size',), area_cell / (sphere_radius**2))
+        if sphere_radius > 0:
+            ds_out['grid_area'] = (
+                ('grid_size',),
+                area_cell / (sphere_radius**2),
+            )
+            ds_out.grid_area.attrs['units'] = 'radians^2'
 
         ds_out['grid_center_lat'] = (('grid_size',), lat_cell)
         ds_out['grid_center_lon'] = (('grid_size',), lon_cell)
@@ -165,7 +170,6 @@ class MpasCellMeshDescriptor(MeshDescriptor):
         ds_out.grid_corner_lat.attrs['units'] = 'radians'
         ds_out.grid_corner_lon.attrs['units'] = 'radians'
         ds_out.grid_imask.attrs['units'] = 'unitless'
-        ds_out.grid_area.attrs['units'] = 'radians^2'
 
         if expand_dist is not None or expand_factor is not None:
             expand_scrip(ds_out, expand_dist, expand_factor)

--- a/pyremap/descriptor/mpas_edge_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_edge_mesh_descriptor.py
@@ -142,10 +142,16 @@ class MpasEdgeMeshDescriptor(MeshDescriptor):
             mask = cells_on_edge[:, i_cell] >= 0
             valid_cells_on_edge[mask] = valid_cells_on_edge[mask] + 1
 
-        ds_out['grid_area'] = (
-            ('grid_size',),
-            0.5 * valid_cells_on_edge * dc_edge * dv_edge / (sphere_radius**2),
-        )
+        if sphere_radius > 0:
+            ds_out['grid_area'] = (
+                ('grid_size',),
+                0.5
+                * valid_cells_on_edge
+                * dc_edge
+                * dv_edge
+                / (sphere_radius**2),
+            )
+            ds_out.grid_area.attrs['units'] = 'radians^2'
 
         ds_out['grid_center_lat'] = (('grid_size',), lat_edge)
         ds_out['grid_center_lon'] = (('grid_size',), lon_edge)
@@ -198,7 +204,6 @@ class MpasEdgeMeshDescriptor(MeshDescriptor):
         ds_out.grid_corner_lat.attrs['units'] = 'radians'
         ds_out.grid_corner_lon.attrs['units'] = 'radians'
         ds_out.grid_imask.attrs['units'] = 'unitless'
-        ds_out.grid_area.attrs['units'] = 'radians^2'
 
         if expand_dist is not None or expand_factor is not None:
             expand_scrip(ds_out, expand_dist, expand_factor)

--- a/pyremap/descriptor/mpas_vertex_mesh_descriptor.py
+++ b/pyremap/descriptor/mpas_vertex_mesh_descriptor.py
@@ -136,10 +136,12 @@ class MpasVertexMeshDescriptor(MeshDescriptor):
                 vertex_area[mask] + kite_areas_on_vertex[mask, icell]
             )
 
-        ds_out['grid_area'] = (
-            ('grid_size',),
-            vertex_area / (sphere_radius**2),
-        )
+        if sphere_radius > 0:
+            ds_out['grid_area'] = (
+                ('grid_size',),
+                vertex_area / (sphere_radius**2),
+            )
+            ds_out.grid_area.attrs['units'] = 'radians^2'
 
         ds_out['grid_center_lat'] = (('grid_size',), lat_vertex)
         ds_out['grid_center_lon'] = (('grid_size',), lon_vertex)
@@ -191,7 +193,6 @@ class MpasVertexMeshDescriptor(MeshDescriptor):
         ds_out.grid_corner_lat.attrs['units'] = 'radians'
         ds_out.grid_corner_lon.attrs['units'] = 'radians'
         ds_out.grid_imask.attrs['units'] = 'unitless'
-        ds_out.grid_area.attrs['units'] = 'radians^2'
 
         if expand_dist is not None or expand_factor is not None:
             expand_scrip(ds_out, expand_dist, expand_factor)

--- a/pyremap/remapper/remapper.py
+++ b/pyremap/remapper/remapper.py
@@ -1,5 +1,3 @@
-import os
-
 from pyremap.remapper.build_map import _build_map
 from pyremap.remapper.ncremap import _ncremap
 from pyremap.remapper.remap_numpy import _remap_numpy
@@ -468,8 +466,6 @@ class Remapper:
             needed).
         """
         _setup_remapper(self)
-        if not os.path.exists(self.map_filename):
-            _build_map(self)
 
         _ncremap(
             self,


### PR DESCRIPTION
This PR:
* Removes building of mapping file in `Remapper.ncremap()` calls.  This causes confusion rather than being helpful.
* Drops grid areas for planar MPAS meshes. We don't have a sphere radius to work from so we should just let the regridder handle it.

## Copilot summary

This pull request refines the `to_scrip` methods across multiple mesh descriptor files and removes unused imports and redundant logic in the `remapper.py` file. Key updates include conditional logic for `grid_area` calculations, ensuring proper handling of `sphere_radius`, and cleanup of unnecessary attributes and imports.

### Updates to `to_scrip` methods:

* Added conditional checks for `sphere_radius > 0` before calculating `grid_area` in `mpas_cell_mesh_descriptor.py`, `mpas_edge_mesh_descriptor.py`, and `mpas_vertex_mesh_descriptor.py`. This ensures calculations only occur when `sphere_radius` is valid and prevents potential errors. (`[[1]](diffhunk://#diff-b8e42ee21f94e07b45520f2c2b8a9572c51aff41f7c9b35ef3184972c709b18fL130-R135)`, `[[2]](diffhunk://#diff-343623030d3692a1c68dcf28804f6d9dc2b197bdc197771f94ef1cbc85571e37R145-R154)`, `[[3]](diffhunk://#diff-56f4a40d8496b6da8d8fe5ce8d3172944c9a0ff005393efa4bc8af72bb049d52R139-R144)`)
* Removed redundant `grid_area` attribute definitions that were no longer necessary after introducing the conditional logic. (`[[1]](diffhunk://#diff-b8e42ee21f94e07b45520f2c2b8a9572c51aff41f7c9b35ef3184972c709b18fL168)`, `[[2]](diffhunk://#diff-343623030d3692a1c68dcf28804f6d9dc2b197bdc197771f94ef1cbc85571e37L201)`, `[[3]](diffhunk://#diff-56f4a40d8496b6da8d8fe5ce8d3172944c9a0ff005393efa4bc8af72bb049d52L194)`)

### Code cleanup in `remapper.py`:

* Removed unused `os` import to streamline the file. (`[pyremap/remapper/remapper.pyL1-L2](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edL1-L2)`)
* Eliminated redundant `os.path.exists` check and the associated `_build_map` call in the `ncremap` method, simplifying the logic. (`[pyremap/remapper/remapper.pyL471-L472](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edL471-L472)`)