### PR TITLE
Allow flags to `parallel_exec` used to build mapping files

### DIFF
--- a/docs/remapper/building_mapping.md
+++ b/docs/remapper/building_mapping.md
@@ -23,7 +23,8 @@ tool.
 - `moab_path`: The path to the MOAB installation, if `mptempest` is not in
   your path.
 - `parallel_exec`: The parallel executable (e.g. `srun` or `mpirun`) to use
-  to run the mapping tool.
+  to run the mapping tool.  This may include additional flags, e.g.
+  `srun --mpi=pmi2`.
 - `use_tmp`: Whether to use a temporary directory for intermediate files.
 
 ## Example

--- a/pyremap/remapper/build_map.py
+++ b/pyremap/remapper/build_map.py
@@ -77,14 +77,15 @@ def _build_map(remapper, logger=None):
     ntasks = remapper.ntasks
     if ntasks > 1:
         parallel_exec = remapper.parallel_exec
-        if parallel_exec == 'srun':
-            args = [parallel_exec, '-n', str(ntasks)] + args
-        elif parallel_exec == 'mpirun':
-            args = [parallel_exec, '-np', str(ntasks)] + args
+        parallel_args = parallel_exec.split(' ')
+        if parallel_args[0] == 'srun':
+            args = parallel_args + ['-n', str(ntasks)] + args
+        elif parallel_args[0] == 'mpirun':
+            args = parallel_args + ['-np', str(ntasks)] + args
         else:
             raise ValueError(
                 f'Unexpected parallel_exec {parallel_exec}. '
-                f'Valid values are "mpirun" or "srun".'
+                f'Valid values are "mpirun" or "srun" with optional flags.'
             )
 
     check_call(args, logger=logger)

--- a/pyremap/remapper/remapper.py
+++ b/pyremap/remapper/remapper.py
@@ -69,8 +69,8 @@ class Remapper:
         MOAB tools must be in the PATH.
 
     parallel_exec : {'mpirun', 'srun'}
-        The command to use for running the mapping tool.  The default is
-        ``mpirun``.
+        The command to use for running the mapping tool, possibly with
+        additional flags.
     """  # noqa: E501
 
     def __init__(
@@ -110,8 +110,8 @@ class Remapper:
             ``esmf``.
 
         parallel_exec : {'mpirun', 'srun'}, optional
-            The command to use for running the mapping tool.  The default is
-            ``mpirun``.
+            The command to use for running the mapping tool, possibly with
+            additional flags.  The default is ``mpirun``.
 
         use_tmp : bool, optional
             If True, use a temporary directory for the SCRIP files.  The
@@ -456,7 +456,9 @@ class Remapper:
 
         parallel_exec : {'srun'}, optional
             The name of the parallel executable to use to launch ncremap.
-            By default, none is used.
+            By default, none is used.  Note that ``self.parallel_exec`` is
+            not used, since that attribute is used to build mapping files, not
+            for ncremap.
 
         Raises
         ------


### PR DESCRIPTION
This is expected to prevent errors in some configurations on some machines (e.g. Chrysalis and Compy).

This pull request updates the handling of the `parallel_exec` parameter in the `pyremap` library to allow for additional flags (e.g., `srun --mpi=pmi2`) and improves the documentation to reflect these changes. The updates ensure better flexibility and clarity when specifying parallel execution commands.

### Enhancements to `parallel_exec` handling:

* **Updated logic for parsing `parallel_exec` with flags**: Modified the `_build_map` function to split `parallel_exec` into arguments, enabling support for additional flags like `srun --mpi=pmi2`. The validation logic was also updated to account for these optional flags. (`pyremap/remapper/build_map.py`, [pyremap/remapper/build_map.pyL80-R88](diffhunk://#diff-129a160e000bfecfdac3efea475ddcf99d3251f6f295871c3c0cc08f3c5bcdf6L80-R88))

* **Updated `Remapper` class documentation**: Changed the description of `parallel_exec` in the `Remapper` class and its `__init__` method to indicate that additional flags can now be included. (`pyremap/remapper/remapper.py`, [[1]](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edL72-R73) [[2]](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edL113-R114)

* **Clarification for `ncremap` parameter**: Enhanced the documentation for the `parallel_exec` parameter in the `ncremap` function to clarify its purpose and distinguish it from `self.parallel_exec`. (`pyremap/remapper/remapper.py`, [pyremap/remapper/remapper.pyL459-R461](diffhunk://#diff-7f2566a2b1ff9f4c7fa6700f874c8e5848dc3c6b39009d37e8482bf2c10256edL459-R461))

### Documentation updates:

* **Example and description updates**: Updated the `building_mapping.md` documentation to include an example of using `parallel_exec` with additional flags, improving clarity for users. (`docs/remapper/building_mapping.md`, [docs/remapper/building_mapping.mdL26-R27](diffhunk://#diff-eb4eb03a4830357711a8589a8c513bacb71d118bba39fe975cc084d81aa59f89L26-R27))