### PR TITLE
Fix documentation of release candidates

### DIFF
--- a/docs/developer_guide/releasing.md
+++ b/docs/developer_guide/releasing.md
@@ -33,15 +33,16 @@ version of `pyremap`, and to update the conda-forge feedstock.
    - Open a PR for the version bump and dependency changes and merge once
      approved.
 
-## Tagging Release Candidates and Stable Releases
+## Tagging and Publishing a Release Candidate
 
 4. **Tagging a Release Candidate**
 
    - For release candidates, **do not create a GitHub release page**. Just
      create a tag from the command line:
 
-     - Make sure your changes are merged into `main`  or your own update
-       branch (e.g. `update-to-2.1.0`) and your local repo is up to date.
+     - Make sure your changes are merged into `main` or your own update branch
+       (e.g. `update-to-2.1.0`) and your local repo is up to date.
+
      - Tag the release candidate (e.g., `2.1.0rc1`):
 
        ```bash
@@ -51,13 +52,50 @@ version of `pyremap`, and to update the conda-forge feedstock.
        git tag 2.1.0rc1
        git push origin 2.1.0rc1
        ```
-       (Replace `2.1.0rc1` with your actual version, and `main` with
-       your branch if needed.)
 
-     > **Note:** This will only create a tag. No release page will be created
-       on GitHub.
+       (Replace `2.1.0rc1` with your actual version, and `main` with your
+       branch if needed.)
 
-5. **Publishing a Stable Release**
+     **Note:** This will only create a tag. No release page will be created on
+     GitHub.
+
+## Updating the conda-forge Feedstock for a Release Candidate
+
+5. **Manual Feedstock Update (Required for Release Candidates)**
+
+   - The conda-forge feedstock does **not** update automatically for release
+     candidates.
+   - You must always create a PR manually, and it must target the `dev`
+     branch of the feedstock.
+
+   Steps:
+
+   - Download the release tarball:
+
+     ```bash
+     wget https://github.com/MPAS-Dev/pyremap/archive/refs/tags/<version>.tar.gz
+     ```
+
+   - Compute the SHA256 checksum:
+
+     ```bash
+     shasum -a 256 <version>.tar.gz
+     ```
+
+   - In the `meta.yaml` of the feedstock recipe:
+     - Set `{% set version = "<version>" %}`
+     - Set the new `sha256` value
+     - Update dependencies if needed
+
+   - Commit, push to a new branch, and open a PR **against the `dev` branch**
+     of the feedstock:
+     https://github.com/conda-forge/pyremap-feedstock
+
+   - Follow any instructions in the PR template and merge once approved
+
+## Releasing a Stable Version
+
+6. **Publishing a Stable Release**
 
    - For stable releases, create a GitHub release page as follows:
 
@@ -68,9 +106,9 @@ version of `pyremap`, and to update the conda-forge feedstock.
      - Generate or manually write release notes
      - Click "Publish release"
 
-## Updating the conda-forge Feedstock
+## Updating the conda-forge Feedstock for a Stable Release
 
-6. **Automatic Feedstock Update (Preferred Method)**
+7. **Automatic Feedstock Update (Preferred Method)**
 
    - Wait for the `regro-cf-autotick-bot` to open a PR at:
      [https://github.com/conda-forge/pyremap-feedstock](https://github.com/conda-forge/pyremap-feedstock)
@@ -81,35 +119,15 @@ version of `pyremap`, and to update the conda-forge feedstock.
      - Confirm the version bump and dependency changes
      - Merge once CI checks pass
 
-   **Note:** If you are impatient, you can accellerate this process by creating
+   **Note:** If you are impatient, you can accelerate this process by creating
    a bot issue at:
    [https://github.com/conda-forge/pyremap-feedstock/issues](https://github.com/conda-forge/pyremap-feedstock/issues)
-   with the subject ``@conda-forge-admin, please update version``.  This
-   will open a new PR with the version within a few minutes.
+   with the subject `@conda-forge-admin, please update version`. This will open
+   a new PR with the version within a few minutes.
 
-7. **Manual Feedstock Update (Fallback Method)**
-
-   If the bot PR does not appear or is too slow, update manually:
-
-   - Download the release tarball:
-
-     ```
-     wget https://github.com/MPAS-Dev/pyremap/archive/refs/tags/<version>.tar.gz
-     ```
-
-   - Compute the SHA256 checksum:
-
-     ```
-     shasum -a 256 <version>.tar.gz
-     ```
-
-   - In the `meta.yaml` of the feedstock recipe:
-     - Set `{% set version = "<version>" %}`
-     - Set the new `sha256` value
-     - Update dependencies if needed
-
-   - Commit, push to a new branch, and open a PR against the feedstock
-   - Follow any instructions in the PR template and merge once approved
+   - If the bot PR does not appear or is too slow, you may update manually (see
+     the manual steps for release candidates above, but target the `main`
+     branch of the feedstock).
 
 ## Post Release Actions
 
@@ -117,7 +135,7 @@ version of `pyremap`, and to update the conda-forge feedstock.
 
    - Install the package in a clean environment to test:
 
-     ```
+     ```bash
      conda create -n test-pyremap -c conda-forge pyremap=<version>
      ```
 


### PR DESCRIPTION
This pull request updates the release process documentation for `pyremap` to clarify workflows for release candidates and stable releases, and to provide detailed instructions for updating the conda-forge feedstock. The most important changes include separating the workflows for tagging release candidates and stable releases, introducing a new section for manually updating the conda-forge feedstock for release candidates, and refining the instructions for stable release feedstock updates.
