### PR TITLE
Base lat/lon regional flag on longitude periodicity

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyremap" %}
-{% set version = "2.1.0" %}
+{% set version = "2.2.0" %}
 {% set python_min = "3.10" %}
 
 package:

--- a/docs/remapper/building_mapping.md
+++ b/docs/remapper/building_mapping.md
@@ -37,3 +37,11 @@ remapper.src_from_lon_lat(lat, lon)
 remapper.dst_from_lon_lat(lat_out, lon_out)
 remapper.build_map()
 ```
+
+```{note}
+For 1D lat/lon grids, whether a grid is treated as regional or global is
+governed by longitude periodicity. Latitude extent does not force a grid to be
+regional, so a zonally periodic but latitude-bounded grid is still global. Use
+the `regional` argument of `src_from_lon_lat`/`dst_from_lon_lat` to override the
+auto-detection.
+```

--- a/docs/remapper/source_grid_setup.md
+++ b/docs/remapper/source_grid_setup.md
@@ -20,6 +20,21 @@ remapper = Remapper()
 remapper.src_from_lon_lat(lat, lon)
 ```
 
+## Regional vs. Global Grids
+By default, both `src_from_lon_lat` and `dst_from_lon_lat` determine whether a
+1D lat/lon grid is regional or global automatically, based on whether the grid
+is periodic in longitude (i.e. its longitudes wrap a full circle). Latitude
+extent does not affect this: a zonally periodic but latitude-bounded grid (a
+polar cap or zonal band) is treated as global so that longitude wraps across
+the antimeridian.
+
+The optional `regional` argument overrides this auto-detection. Pass
+`regional=True` to force a grid to be treated as regional or `regional=False`
+to force it to be treated as global:
+```python
+remapper.src_from_lon_lat('grid_file.nc', regional=False)
+```
+
 ## Setting Source Descriptor Directly
 The `src_descriptor` attribute can be set directly to define the source grid.
 This is useful when you already have a pre-defined grid descriptor or need

--- a/pyremap/descriptor/lat_lon_2d_grid_descriptor.py
+++ b/pyremap/descriptor/lat_lon_2d_grid_descriptor.py
@@ -50,7 +50,7 @@ class LatLon2DGridDescriptor(MeshDescriptor):
         The history attribute written to SCRIP files
     """
 
-    def __init__(self, mesh_name=None, regional=True):
+    def __init__(self, mesh_name=None, regional=None):
         """
         Construct a mesh descriptor
 
@@ -59,8 +59,13 @@ class LatLon2DGridDescriptor(MeshDescriptor):
             names
 
         regional : bool or None, optional
-            Whether this is a regional or global grid
+            Whether this is a regional or global grid.  Unlike the 1D
+            ``LatLonGridDescriptor``, a 2D grid cannot be classified
+            automatically, so ``None`` is treated as regional (the default).
+            Pass ``regional=False`` for global grids with 2D lat/lon.
         """
+        if regional is None:
+            regional = True
         super().__init__(mesh_name=mesh_name, regional=regional)
         self.lat: Optional[np.ndarray] = None
         self.lon: Optional[np.ndarray] = None
@@ -77,7 +82,7 @@ class LatLon2DGridDescriptor(MeshDescriptor):
         lat_var_name='lat',
         lon_var_name='lon',
         mesh_name=None,
-        regional=True,
+        regional=None,
     ):
         """
         Read the lat-lon grid from a file with the given lat/lon var names.
@@ -103,7 +108,10 @@ class LatLon2DGridDescriptor(MeshDescriptor):
             names
 
         regional : bool or None, optional
-            Whether this is a regional or global grid
+            Whether this is a regional or global grid.  A 2D grid cannot be
+            classified automatically, so ``None`` is treated as regional (the
+            default).  Pass ``regional=False`` for global grids with 2D
+            lat/lon.
         """
         if ds is None:
             ds = xr.open_dataset(filename)

--- a/pyremap/descriptor/lat_lon_grid_descriptor.py
+++ b/pyremap/descriptor/lat_lon_grid_descriptor.py
@@ -327,8 +327,6 @@ class LatLonGridDescriptor(MeshDescriptor):
         # set the name of the grid
         dlat = self.lat[1] - self.lat[0]
         dlon = self.lon[1] - self.lon[0]
-        lon_range = self.lon_corner[-1] - self.lon_corner[0]
-        lat_range = self.lat_corner[-1] - self.lat_corner[0]
         if 'degree' in self.units:
             units = 'degree'
         elif 'rad' in self.units:
@@ -337,18 +335,31 @@ class LatLonGridDescriptor(MeshDescriptor):
             raise ValueError(f'Could not figure out units {self.units}')
 
         if self.regional is None:
-            self.regional = False
-            if units == 'degree':
-                if np.abs(lon_range - 360.0) > 1e-10:
-                    self.regional = True
-                if np.abs(lat_range - 180.0) > 1e-10:
-                    self.regional = True
-            else:
-                if np.abs(lon_range - 2.0 * np.pi) > 1e-10:
-                    self.regional = True
-                if np.abs(lat_range - np.pi) > 1e-10:
-                    self.regional = True
+            # A lat/lon grid is "global" (not regional) when it is
+            # periodic in longitude. Latitude is never periodic, so a
+            # latitude-bounded but zonally-periodic grid (polar cap,
+            # zonal band) is still global in the sense ESMF needs:
+            # longitude wraps across the antimeridian.
+            full_circle = 360.0 if units == 'degree' else 2.0 * np.pi
+            self.regional = not _is_lon_periodic(self.lon, full_circle)
         if self.mesh_name is None:
             self.mesh_name = (
                 f'{round_res(abs(dlat))}x{round_res(abs(dlon))}{units}'
             )
+
+
+def _is_lon_periodic(lon, full_circle):
+    """Return True if 1D longitude centers wrap a full circle.
+
+    Handles both the non-duplicate convention (centers span
+    ``full_circle - dlon``) and the duplicate-endpoint convention
+    (both -180 and +180 present, centers span ``full_circle``).
+    ``full_circle`` is 360.0 (degrees) or 2*pi (radians). Tolerance
+    scales with the cell size.
+    """
+    dlon = lon[1] - lon[0]
+    center_span = lon[-1] - lon[0]
+    tol = 1e-3 * abs(dlon)
+    closes = abs(abs(center_span) + abs(dlon) - full_circle) <= tol
+    duplicate = abs(abs(center_span) - full_circle) <= tol
+    return bool(closes or duplicate)

--- a/pyremap/remapper/descriptor.py
+++ b/pyremap/remapper/descriptor.py
@@ -110,13 +110,20 @@ def _get_lon_lat_descriptor(info) -> 'MeshDescriptor':
                     f'{len(ds[lat].dims)}.'
                 )
 
+        regional = info.get('regional', None)
         if lon_lat_1d:
             descriptor = LatLonGridDescriptor.read(
-                filename=filename, lon_var_name=lon, lat_var_name=lat
+                filename=filename,
+                lon_var_name=lon,
+                lat_var_name=lat,
+                regional=regional,
             )
         else:
             descriptor = LatLon2DGridDescriptor.read(
-                filename=filename, lon_var_name=lon, lat_var_name=lat
+                filename=filename,
+                lon_var_name=lon,
+                lat_var_name=lat,
+                regional=regional,
             )
 
     if 'name' in info:

--- a/pyremap/remapper/remapper.py
+++ b/pyremap/remapper/remapper.py
@@ -137,7 +137,12 @@ class Remapper:
         self._matrix = None
 
     def src_from_lon_lat(
-        self, filename, mesh_name=None, lon_var='lon', lat_var='lat'
+        self,
+        filename,
+        mesh_name=None,
+        lon_var='lon',
+        lat_var='lat',
+        regional=None,
     ):
         """
         Set the source grid from a file with a longitude-latitude grid.  The
@@ -157,6 +162,11 @@ class Remapper:
 
         lat_var : str, optional
             The name of the latitude coordinate in the file
+
+        regional : bool or None, optional
+            Whether this is a regional or global grid.  If ``None``, this will
+            be determined automatically based on whether the grid is periodic
+            in longitude.
         """
         src = dict()
         src['type'] = 'lon-lat'
@@ -165,10 +175,17 @@ class Remapper:
         src['lat'] = lat_var
         if mesh_name is not None:
             src['name'] = mesh_name
+        if regional is not None:
+            src['regional'] = regional
         self.src_grid_info = src
 
     def dst_from_lon_lat(
-        self, filename, mesh_name=None, lon_var='lon', lat_var='lat'
+        self,
+        filename,
+        mesh_name=None,
+        lon_var='lon',
+        lat_var='lat',
+        regional=None,
     ):
         """
         Set the destination grid from a file with a longitude-latitude grid.
@@ -188,6 +205,11 @@ class Remapper:
 
         lat_var : str, optional
             The name of the latitude coordinate in the file
+
+        regional : bool or None, optional
+            Whether this is a regional or global grid.  If ``None``, this will
+            be determined automatically based on whether the grid is periodic
+            in longitude.
         """
         dst = dict()
         dst['type'] = 'lon-lat'
@@ -196,6 +218,8 @@ class Remapper:
         dst['lat'] = lat_var
         if mesh_name is not None:
             dst['name'] = mesh_name
+        if regional is not None:
+            dst['regional'] = regional
         self.dst_grid_info = dst
 
     def dst_global_lon_lat(self, dlon, dlat, lon_min=-180.0, mesh_name=None):

--- a/pyremap/version.py
+++ b/pyremap/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (2, 1, 0)
+__version_info__ = (2, 2, 0)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,8 +14,6 @@ Unit test infrastructure, adapted from approach of xarray.
 
 import os
 import unittest
-import warnings
-from contextlib import contextmanager
 from shutil import copytree, ignore_patterns
 
 import numpy as np
@@ -99,11 +97,3 @@ class TestCase(unittest.TestCase):
                 f"Dimensions for variable '{var}' do not match: "
                 f'{dims1} != {dims2}'
             )
-
-    @contextmanager
-    def assertWarns(self, message):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', message)
-            yield
-            assert len(w) > 0
-            assert all(message in str(wi.message) for wi in w)

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -239,6 +239,62 @@ class TestInterp(TestCase):
         self.assertDimsEqual(ds_remapped, ds_ref)
         self.assertDatasetApproxEqual(ds_remapped, ds_ref)
 
+    def test_regional_classification(self):
+        """
+        test that the ``regional`` flag of a 1D lat/lon grid is governed by
+        longitude periodicity, not latitude extent, and that an explicit
+        ``regional=`` argument overrides the auto-detection
+        """
+        # ``create`` treats its inputs as corners and derives centers as
+        # midpoints, so corners are chosen so the centers reproduce each
+        # convention (1 degree resolution).
+
+        # (a) duplicate-endpoint global longitude (centers -180..180) with a
+        #     southern latitude cap (the OI_Climatology case) -> global
+        lon_corner = np.arange(-180.5, 181.0, 1.0)
+        lat_corner = np.arange(-90.0, -44.0, 1.0)
+        descriptor = LatLonGridDescriptor.create(lat_corner, lon_corner)
+        self.assertFalse(descriptor.regional)
+
+        # (b) standard non-duplicate global longitude (centers -180..179),
+        #     full globe -> global
+        lon_corner = np.arange(-180.5, 180.0, 1.0)
+        lat_corner = np.arange(-90.5, 91.0, 1.0)
+        descriptor = LatLonGridDescriptor.create(lat_corner, lon_corner)
+        self.assertFalse(descriptor.regional)
+
+        # (c) full globe via linspace -90..90 / -180..180 -> global
+        lat = np.linspace(-90.0, 90.0, 91)
+        lon = np.linspace(-180.0, 180.0, 181)
+        descriptor = LatLonGridDescriptor.create(lat, lon)
+        self.assertFalse(descriptor.regional)
+
+        # (d) a genuinely regional longitude box (0..90) -> regional
+        lon_corner = np.arange(0.0, 91.0, 1.0)
+        lat_corner = np.arange(-90.0, -44.0, 1.0)
+        descriptor = LatLonGridDescriptor.create(lat_corner, lon_corner)
+        self.assertTrue(descriptor.regional)
+
+        # (e) zonally periodic but latitude-capped (a northern zonal band)
+        #     -> global
+        lon_corner = np.arange(-180.5, 181.0, 1.0)
+        lat_corner = np.arange(40.0, 71.0, 1.0)
+        descriptor = LatLonGridDescriptor.create(lat_corner, lon_corner)
+        self.assertFalse(descriptor.regional)
+
+        # explicit override wins in both directions
+        lat = np.linspace(-90.0, 90.0, 91)
+        lon = np.linspace(-180.0, 180.0, 181)
+        descriptor = LatLonGridDescriptor.create(lat, lon, regional=True)
+        self.assertTrue(descriptor.regional)
+
+        lon_corner = np.arange(0.0, 91.0, 1.0)
+        lat_corner = np.arange(-90.0, -44.0, 1.0)
+        descriptor = LatLonGridDescriptor.create(
+            lat_corner, lon_corner, regional=False
+        )
+        self.assertFalse(descriptor.regional)
+
     def test_latlon_file_scrip(self):
         """
         test writing a SCRIP file for a lat/lon grid file


### PR DESCRIPTION
A 1D lat/lon grid was classified as regional whenever its corner longitudes did not span exactly 360 degrees or its corner latitudes did not span 180 degrees.  Both tests misfire for the duplicate-endpoint convention (longitude centers -180..180, corners overshoot to +/-180.1) and for any latitude-bounded grid (polar cap, zonal band).  As a result ESMF received --src_regional, disabled longitude wrap, and produced a thin band of reduced coverage / NaN holes along the antimeridian.

Classify a 1D lat/lon grid as global (not regional) whenever it is periodic in longitude, using cell centers with a tolerance that scales with the cell size so both the non-duplicate and duplicate-endpoint conventions are handled.  Latitude extent no longer forces a grid to be regional, since latitude is never periodic.

Add a public `regional=` override (default None = auto-detect) to `Remapper.src_from_lon_lat`/`dst_from_lon_lat`, forwarded through the grid-info dict to the descriptors.  Give `LatLon2DGridDescriptor` the same `regional=None` signature as `LatLonGridDescriptor`, with None treated as regional (its existing default) since a 2D grid cannot be classified automatically.

Add `test_regional_classification` covering the duplicate-endpoint, non-duplicate, full-globe, regional-box and latitude-capped cases plus the explicit override, and document the new argument.

This PR also updates to v2.2.0 in anticipation of a new release.